### PR TITLE
11 |  Bundle Improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dev": "concurrently \"yarn run dev-client\" \"yarn run dev-server\"",
     "build":
       "yarn run clean && yarn run prep && NODE_ENV=production webpack --progress --colors",
-    "prep": "mkdir build/ && cp src/index.html build/",
+    "prep":
+      "mkdir build/ && cp src/index.html build/ && mkdir build/assets/ && cp -r src/assets/ build/assets/",
     "clean": "rm -rf build/",
     "lint:scripts": "eslint src test --cache",
     "lint:styles": "stylelint 'src/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -7,15 +7,11 @@
   "author": "Benjamin Baum <benjaminjbaum@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "dev-client":
-      "yarn run clean && yarn run prep && webpack --watch --colors --progress",
-    "dev-server":
-      "nodemon --watch src/server --watch node_modules src/server/index.js localhost:8080",
+    "dev-client": "yarn run clean && yarn run prep && webpack --watch --colors --progress",
+    "dev-server": "nodemon --watch src/server --watch node_modules src/server/index.js localhost:8080",
     "dev": "concurrently \"yarn run dev-client\" \"yarn run dev-server\"",
-    "build":
-      "yarn run clean && yarn run prep && NODE_ENV=production webpack --progress --colors",
-    "prep":
-      "mkdir build/ && cp src/index.html build/ && mkdir build/assets/ && cp -r src/assets/ build/assets/",
+    "build": "yarn run clean && yarn run prep && NODE_ENV=production webpack --progress --colors",
+    "prep": "mkdir build/ && cp src/index.html build/ && mkdir build/assets/",
     "clean": "rm -rf build/",
     "lint:scripts": "eslint src test --cache",
     "lint:styles": "stylelint 'src/**/*.js'",
@@ -25,7 +21,12 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.js": ["prettier --write", "eslint --cache", "stylelint", "git add"]
+    "*.js": [
+      "prettier --write",
+      "eslint --cache",
+      "stylelint",
+      "git add"
+    ]
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -53,6 +54,7 @@
     "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-standard": "^3.0.1",
     "express": "^4.16.2",
+    "file-loader": "^1.1.6",
     "flow-bin": "^0.61.0",
     "husky": "^0.14.3",
     "jasmine-core": "^2.8.0",
@@ -74,7 +76,6 @@
     "stylelint-config-standard": "^18.0.0",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.2.1",
-    "url-loader": "^0.6.2",
     "webpack": "^3.10.0",
     "webpack-dev-middleware": "^2.0.2",
     "webpack-hot-middleware": "^2.21.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,7 +82,14 @@ var config = {
     : {
         hot: true
       },
-  plugins: prod ? [] : [new webpack.HotModuleReplacementPlugin()]
+  plugins: prod
+    ? [
+        new webpack.DefinePlugin({
+          "process.env.NODE_ENV": JSON.stringify("production")
+        }),
+        new webpack.optimize.UglifyJsPlugin()
+      ]
+    : [new webpack.HotModuleReplacementPlugin()]
 };
 
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,7 @@ var config = {
       }
     ]
   },
-  devtool: "inline-source-map",
+  devtool: prod ? undefined : "eval-source-map",
   devServer: prod
     ? {}
     : {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,10 @@ var config = {
         include: assetsDir,
         use: [
           {
-            loader: "url-loader"
+            loader: "file-loader",
+            options: {
+              outputPath: "assets/"
+            }
           }
         ]
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,6 +2878,13 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+file-loader@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.6.tgz#7b9a8f2c58f00a77fddf49e940f7ac978a3ea0e8"
+  dependencies:
+    loader-utils "^1.0.2"
+    schema-utils "^0.3.0"
+
 file-uri-to-path@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -4722,7 +4729,7 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
-mime@^1.3.4, mime@^1.4.1, mime@^1.5.0:
+mime@^1.3.4, mime@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
@@ -7982,14 +7989,6 @@ update-notifier@^2.3.0:
 url-join@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.2.tgz#c072756967ad24b8b59e5741551caac78f50b8b7"
-
-url-loader@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-0.6.2.tgz#a007a7109620e9d988d14bce677a1decb9a993f7"
-  dependencies:
-    loader-utils "^1.0.2"
-    mime "^1.4.1"
-    schema-utils "^0.3.0"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Issue**
#11 

**Work Done**
- do not add assets as inline data urls; instead, use `file-loader` to make them available in the `build/` dir
- Change sourcemap type and only generate sourcemaps in dev/test mode
- uglify code in prod build

@jellegerbrandy do you still want to generate any kind of sourcemaps in production? If so, which from [this list](https://webpack.js.org/configuration/devtool/) do you think would be best?