### PR TITLE
22 - bump player version to make loading faster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12401,6 +12401,15 @@
         "warning": "3.0.0"
       }
     },
+    "hlsjs-ipfs-loader": {
+      "version": "github:ya7ya/hlsjs-ipfs-loader#bd890b9e78f2c273fcb1dc4e1d43ad0afc69558c",
+      "requires": {
+        "aegir": "11.0.2",
+        "debug": "3.1.0",
+        "gulp": "3.9.1",
+        "lodash": "4.17.4"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -18943,9 +18952,9 @@
       }
     },
     "paratii-mediaplayer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/paratii-mediaplayer/-/paratii-mediaplayer-1.1.0.tgz",
-      "integrity": "sha512-MOaZy2dChvwCPYmR7H2EBt02Q+1ISABeZ+TBnaYwXI3DEgY286JaSeUcl9SnXwkV4yEQi+zItyeQcq5PmX1ljg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/paratii-mediaplayer/-/paratii-mediaplayer-1.1.1.tgz",
+      "integrity": "sha512-ZPxciRCdmYrVVdvgTgf3UBdpI4WYtA/3OlslRMNwqtSZn8Ilz2z3wunkmYbnDeqaXGYWjq3cPhZpRDc2vgt7nA==",
       "requires": {
         "hlsjs-ipfs-loader": "github:ya7ya/hlsjs-ipfs-loader#bd890b9e78f2c273fcb1dc4e1d43ad0afc69558c",
         "ipfs": "github:ya7ya/js-ipfs#697e4c1cee35b65466c84b65c3fbc01d2564005a",
@@ -18958,15 +18967,6 @@
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.0.3.tgz",
           "integrity": "sha512-av8LNZGBl4cg2r4ZhWqghJOxi2P8UCcWhdmrFgcHPMmUJ6jx1FbnyxjwL4URYzMK3QJg60qeMefQhv9G14oYKA=="
-        },
-        "hlsjs-ipfs-loader": {
-          "version": "github:ya7ya/hlsjs-ipfs-loader#bd890b9e78f2c273fcb1dc4e1d43ad0afc69558c",
-          "requires": {
-            "aegir": "11.0.2",
-            "debug": "3.1.0",
-            "gulp": "3.9.1",
-            "lodash": "4.17.4"
-          }
         },
         "ipfs": {
           "version": "github:ya7ya/js-ipfs#697e4c1cee35b65466c84b65c3fbc01d2564005a",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3870,6 +3870,7 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
+            "fsevents": "1.1.3",
             "glob-parent": "2.0.0",
             "inherits": "2.0.1",
             "is-binary-path": "1.0.1",
@@ -4365,6 +4366,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.1",
         "is-binary-path": "1.0.1",
@@ -9739,6 +9741,795 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
     "fsm": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fsm/-/fsm-1.0.2.tgz",
@@ -11114,6 +11905,13 @@
             "lodash.keys": "3.1.2",
             "lodash.restparam": "3.6.1",
             "lodash.templatesettings": "3.1.1"
+          },
+          "dependencies": {
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+            }
           }
         },
         "lodash.templatesettings": {
@@ -11601,15 +12399,6 @@
         "resolve-pathname": "2.2.0",
         "value-equal": "0.4.0",
         "warning": "3.0.0"
-      }
-    },
-    "hlsjs-ipfs-loader": {
-      "version": "github:ya7ya/hlsjs-ipfs-loader#91008eaf4cf696687c48e674d883e248c049beee",
-      "requires": {
-        "aegir": "11.0.2",
-        "gulp": "3.9.1",
-        "lodash": "4.17.4",
-        "streamspeed": "1.1.0"
       }
     },
     "hmac-drbg": {
@@ -17143,6 +17932,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.0",
+            "fsevents": "1.1.3",
             "glob-parent": "3.1.0",
             "inherits": "2.0.1",
             "is-binary-path": "1.0.1",
@@ -18153,11 +18943,11 @@
       }
     },
     "paratii-mediaplayer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/paratii-mediaplayer/-/paratii-mediaplayer-1.0.4.tgz",
-      "integrity": "sha512-7m/nAAZ33A4mKdgsCTcOvBe0J11691n8THr8quLGja9nWPHRgvc4wNG1fjFXF3Zrqk/Xf8iT+2/OiSXB4U3wbA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/paratii-mediaplayer/-/paratii-mediaplayer-1.1.0.tgz",
+      "integrity": "sha512-MOaZy2dChvwCPYmR7H2EBt02Q+1ISABeZ+TBnaYwXI3DEgY286JaSeUcl9SnXwkV4yEQi+zItyeQcq5PmX1ljg==",
       "requires": {
-        "hlsjs-ipfs-loader": "github:ya7ya/hlsjs-ipfs-loader#91008eaf4cf696687c48e674d883e248c049beee",
+        "hlsjs-ipfs-loader": "github:ya7ya/hlsjs-ipfs-loader#bd890b9e78f2c273fcb1dc4e1d43ad0afc69558c",
         "ipfs": "github:ya7ya/js-ipfs#697e4c1cee35b65466c84b65c3fbc01d2564005a",
         "ipfs-bitswap": "0.17.4",
         "resolve-url-loader": "2.2.1",
@@ -18168,6 +18958,15 @@
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.0.3.tgz",
           "integrity": "sha512-av8LNZGBl4cg2r4ZhWqghJOxi2P8UCcWhdmrFgcHPMmUJ6jx1FbnyxjwL4URYzMK3QJg60qeMefQhv9G14oYKA=="
+        },
+        "hlsjs-ipfs-loader": {
+          "version": "github:ya7ya/hlsjs-ipfs-loader#bd890b9e78f2c273fcb1dc4e1d43ad0afc69558c",
+          "requires": {
+            "aegir": "11.0.2",
+            "debug": "3.1.0",
+            "gulp": "3.9.1",
+            "lodash": "4.17.4"
+          }
         },
         "ipfs": {
           "version": "github:ya7ya/js-ipfs#697e4c1cee35b65466c84b65c3fbc01d2564005a",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "immutable": "^3.8.2",
     "js-cookie": "^2.2.0",
     "paratii-lib": "github:Paratii-Video/paratii-lib#11d576ecac029309513119c94ca2d4b62b2455ac",
-    "paratii-mediaplayer": "^1.1.0",
+    "paratii-mediaplayer": "^1.1.1",
     "query-string": "^5.0.1",
     "react": "^16.2.0",
     "react-blockies": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "immutable": "^3.8.2",
     "js-cookie": "^2.2.0",
     "paratii-lib": "github:Paratii-Video/paratii-lib#11d576ecac029309513119c94ca2d4b62b2455ac",
-    "paratii-mediaplayer": "^1.0.4",
+    "paratii-mediaplayer": "^1.1.0",
     "query-string": "^5.0.1",
     "react": "^16.2.0",
     "react-blockies": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "clappr": "^0.2.78",
     "immutable": "^3.8.2",
     "js-cookie": "^2.2.0",
+    "lodash.debounce": "^4.0.8",
     "paratii-lib": "github:Paratii-Video/paratii-lib#11d576ecac029309513119c94ca2d4b62b2455ac",
     "paratii-mediaplayer": "^1.1.1",
     "query-string": "^5.0.1",

--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -57,6 +57,8 @@ const OverlayWrapper = styled.div`
   cursor: pointer;
 `
 
+const HIDE_CONTROLS_THRESHOLD: number = 2000
+
 class Play extends Component<Props, State> {
   player: ClapprPlayer
   onOverlayClick: () => void
@@ -156,11 +158,11 @@ class Play extends Component<Props, State> {
 
   maybeHideControls = (): void => {
     this.playerHideTimeout = setTimeout(() => {
-      if (Date.now() - this.lastMouseMove > 2000) {
+      if (Date.now() - this.lastMouseMove > HIDE_CONTROLS_THRESHOLD) {
         this.player.core.mediaControl.resetUserKeepVisible()
         this.player.core.mediaControl.hide()
       }
-    }, 2250)
+    }, HIDE_CONTROLS_THRESHOLD + 250)
   }
 
   getVideoId (): string {

--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -4,8 +4,9 @@ import React, { Component } from 'react'
 import { Events } from 'clappr'
 import styled from 'styled-components'
 import CreatePlayer from 'paratii-mediaplayer'
-import VideoRecord from 'records/VideoRecords'
+import debounce from 'lodash.debounce'
 
+import VideoRecord from 'records/VideoRecords'
 import VideoOverlay from 'components/VideoOverlay'
 
 import type { ClapprPlayer } from 'types/ApplicationTypes'
@@ -131,11 +132,15 @@ class Play extends Component<Props, State> {
     }
   }
 
-  onMouseMove = (): void => {
-    this.lastMouseMove = Date.now()
-    clearTimeout(this.playerHideTimeout)
-    this.maybeHideControls()
-  }
+  onMouseMove = debounce(
+    (): void => {
+      this.lastMouseMove = Date.now()
+      clearTimeout(this.playerHideTimeout)
+      this.maybeHideControls()
+    },
+    150,
+    { leading: true }
+  )
 
   onOverlayMouseLeave = (): void => {
     if (this.player) {

--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -17,7 +17,7 @@ type Props = {
   setSelectedVideo: ({ id: string }) => void,
   fetchVideo: (id: string) => void,
   isPlaying: boolean,
-  togglePlayPause: (play: boolean) => void,
+  togglePlayPause: (play: ?boolean) => void,
   isAttemptingPlay: boolean,
   attemptPlay: () => void,
   video: ?VideoRecord,
@@ -120,9 +120,13 @@ class Play extends Component<Props, State> {
   }
 
   onOverlayClick (): void {
-    const { attemptPlay } = this.props
-
-    attemptPlay()
+    if (this.player) {
+      if (this.player.isPlaying()) {
+        this.player.pause()
+      } else {
+        this.player.play()
+      }
+    }
   }
 
   onOverlayMouseEnter = (): void => {

--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -24,7 +24,7 @@ type Props = {
 }
 
 type State = {
-  showingControls: boolean
+  mouseInOverlay: boolean
 }
 
 const Wrapper = styled.div`
@@ -64,7 +64,7 @@ class Play extends Component<Props, State> {
     super(props)
 
     this.state = {
-      showingControls: false
+      mouseInOverlay: false
     }
 
     this.onOverlayClick = this.onOverlayClick.bind(this)
@@ -90,20 +90,22 @@ class Play extends Component<Props, State> {
       if (container) {
         container.on(Events.CONTAINER_MEDIACONTROL_HIDE, () => {
           this.setState((prevState: State) => {
-            if (prevState.showingControls) {
+            if (prevState.mouseInOverlay) {
               return {
-                showingControls: false
+                mouseInOverlay: false
               }
             }
+            return {}
           })
         })
         container.on(Events.CONTAINER_MEDIACONTROL_SHOW, () => {
           this.setState((prevState: State) => {
-            if (!prevState.showingControls) {
+            if (!prevState.mouseInOverlay) {
               return {
-                showingControls: true
+                mouseInOverlay: true
               }
             }
+            return {}
           })
         })
       }
@@ -119,6 +121,14 @@ class Play extends Component<Props, State> {
   onOverlayMouseEnter = (): void => {
     if (this.player) {
       this.player.core.mediaControl.show()
+      this.player.core.mediaControl.setUserKeepVisible()
+    }
+  }
+
+  onOverlayMouseLeave = (): void => {
+    if (this.player) {
+      this.player.core.mediaControl.resetUserKeepVisible()
+      this.player.core.mediaControl.hide()
     }
   }
 
@@ -144,7 +154,6 @@ class Play extends Component<Props, State> {
   componentWillReceiveProps (nextProps: Props): void {
     const { isAttemptingPlay } = this.props
     let ipfsHash = ''
-    console.log(nextProps)
     if (nextProps.video) {
       if (
         this.props.video == null ||
@@ -176,7 +185,7 @@ class Play extends Component<Props, State> {
   }
 
   shouldShowVideoOverlay (): boolean {
-    return this.state.showingControls
+    return this.state.mouseInOverlay
   }
 
   render () {
@@ -184,7 +193,10 @@ class Play extends Component<Props, State> {
       <Wrapper>
         <PlayerWrapper>
           {this.shouldShowVideoOverlay() && (
-            <OverlayWrapper onMouseEnter={this.onOverlayMouseEnter}>
+            <OverlayWrapper
+              onMouseEnter={this.onOverlayMouseEnter}
+              onMouseLeave={this.onOverlayMouseLeave}
+            >
               <VideoOverlay {...this.props} onClick={this.onOverlayClick} />
             </OverlayWrapper>
           )}

--- a/src/scripts/components/VideoOverlay.js
+++ b/src/scripts/components/VideoOverlay.js
@@ -146,7 +146,7 @@ class VideoOverlay extends Component<Props, State> {
                   onClick={this.onProfileButtonClick}
                   onClose={this.closePopover}
                   popoverPortal={this.popoverWrapperRef}
-                  popoverOpen={true || openPopover === 'profile'}
+                  popoverOpen={openPopover === 'profile'}
                 />
               </ButtonWrapper>
             ) : null}

--- a/src/scripts/components/VideoOverlay.js
+++ b/src/scripts/components/VideoOverlay.js
@@ -136,7 +136,7 @@ class VideoOverlay extends Component<Props, State> {
     const ProfileButton: ?Class<React.Component<any>> = this.state.buttons
       .profile
     return (
-      <Overlay id="video-overlay" onClick={onClick}>
+      <Overlay data-test-id="video-overlay" onClick={onClick}>
         <TopBar>
           <Title>{this.getVideoTitle()}</Title>
           <ButtonGroup hide={!!this.state.openPopover}>

--- a/src/scripts/components/VideoOverlay.js
+++ b/src/scripts/components/VideoOverlay.js
@@ -30,7 +30,7 @@ const Overlay = styled.div`
   display: flex;
   flex-direction: column;
   color: white;
-  background: rgba(0, 0, 0, 0.8);
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0));
   padding: ${overlayPadding};
   box-sizing: border-box;
 `

--- a/src/scripts/reducers/PlayerReducer.js
+++ b/src/scripts/reducers/PlayerReducer.js
@@ -13,7 +13,7 @@ import type { Action } from 'types/ApplicationTypes'
 const reducer = {
   [PLAYER_TOGGLE_PLAYPAUSE]: (state: PlayerRecord, action: Action<boolean>) =>
     state.merge({
-      isPlaying: action.payload,
+      isPlaying: action.payload || !state.get('isPlaying'),
       isAttemptingPlay: false
     }),
   [PLAYER_ATTEMPT_PLAY]: (state: PlayerRecord) =>

--- a/src/scripts/types/ApplicationTypes.js
+++ b/src/scripts/types/ApplicationTypes.js
@@ -49,9 +49,15 @@ type EventEmitter = {
 // TODO move this into paratii-mediaplayer repo
 type ClapprCore = EventEmitter & {}
 
+type ClapprContainer = EventEmitter & {}
+
 export type ClapprPlayer = EventEmitter & {
   core: {
-    getCurrentPlayback: () => ClapprCore
+    getCurrentPlayback: () => ClapprCore,
+    getCurrentContainer: () => ClapprContainer,
+    mediaControl: {
+      show: () => void
+    }
   },
   play: () => void
 }

--- a/src/scripts/types/ApplicationTypes.js
+++ b/src/scripts/types/ApplicationTypes.js
@@ -62,7 +62,9 @@ export type ClapprPlayer = EventEmitter & {
       resetUserKeepVisible: () => void
     }
   },
-  play: () => void
+  isPlaying: () => boolean,
+  play: () => void,
+  pause: () => void
 }
 
 // TODO move this into paratii-lib repo

--- a/src/scripts/types/ApplicationTypes.js
+++ b/src/scripts/types/ApplicationTypes.js
@@ -56,7 +56,10 @@ export type ClapprPlayer = EventEmitter & {
     getCurrentPlayback: () => ClapprCore,
     getCurrentContainer: () => ClapprContainer,
     mediaControl: {
-      show: () => void
+      show: () => void,
+      hide: () => void,
+      setUserKeepVisible: () => void,
+      resetUserKeepVisible: () => void
     }
   },
   play: () => void

--- a/test/functional-tests/player.test.js
+++ b/test/functional-tests/player.test.js
@@ -87,7 +87,8 @@ describe('Player:', function () {
   describe('portal player', () => {
     it('plays a video', () => {
       browser.url(`http://localhost:8080/play/${videoId}`)
-      browser.waitAndClick('#video-overlay')
+      browser.waitAndClick('#player')
+      browser.waitAndClick('[data-test-id="video-overlay"]')
 
       browser.waitUntil(() => {
         return browser.execute(() => {
@@ -98,10 +99,12 @@ describe('Player:', function () {
     })
     it('shows the video title on the overlay', function () {
       browser.url(`http://localhost:8080/play/${videoId}`)
-      browser.waitForText('#video-overlay', 'Test 1')
+      browser.waitAndClick('#player')
+      browser.waitForText('[data-test-id="video-overlay"]', 'Test 1')
     })
     it('does not render a profile button', function () {
       browser.url(`http://localhost:8080/play/${videoId}`)
+      browser.waitAndClick('#player')
       browser.pause(250)
       assert.equal(
         browser.isExisting('[data-test-id="overlay-profile-button"]'),
@@ -113,7 +116,8 @@ describe('Player:', function () {
   describe('embedded player', () => {
     it('plays a video', () => {
       browser.url(`http://localhost:8080/embed/${videoId}`)
-      browser.waitAndClick('#video-overlay')
+      browser.waitAndClick('#player')
+      browser.waitAndClick('[data-test-id="video-overlay"]')
 
       browser.waitUntil(() => {
         return browser.execute(() => {
@@ -124,10 +128,12 @@ describe('Player:', function () {
     })
     it('shows the video title on the overlay', function () {
       browser.url(`http://localhost:8080/embed/${videoId}`)
-      browser.waitForText('#video-overlay', 'Test 1')
+      browser.waitAndClick('#player')
+      browser.waitForText('[data-test-id="video-overlay"]', 'Test 1')
     })
     it('renders a profile button', function () {
       browser.url(`http://localhost:8080/embed/${videoId}`)
+      browser.waitAndClick('#player')
       browser.waitForClickable('[data-test-id="overlay-profile-button"]')
     })
   })


### PR DESCRIPTION
Take new `paratii-mediaplayer` version to increase load performance! Thanks @ya7ya 

![playerload](https://user-images.githubusercontent.com/7697924/36063391-3695501a-0e4a-11e8-8a03-6c25701a0da9.gif)

I'm going to push a new version of mediaplayer and include those changes in this PR before merging. Change will be to re-enable hiding of mediaplayer controls. https://github.com/Paratii-Video/paratii-mediaplayer/pull/36

Also, fix hiding/showing of controls and play/pause controls by clicking on video overlay.

Next will include transitions for the player elements and more tests!!