### PR TITLE
PROOF OF CONCEPT - DO NOT MERGE - rewrite player controls w/ react

### DIFF
--- a/src/assets/img/pause-icon.svg
+++ b/src/assets/img/pause-icon.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="13px" height="14px" viewBox="0 0 13 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 43.2 (39069) - http://www.bohemiancoding.com/sketch -->
+    <title>Group</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="player_v01" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="mvp-paused-signup" transform="translate(-154.000000, -375.000000)" fill="#FFFFFF">
+            <g id="player-control" transform="translate(88.000000, 321.000000)">
+                <g id="slide">
+                    <g id="Group" transform="translate(66.000000, 54.000000)">
+                        <rect id="Rectangle" x="0" y="0" width="5" height="14"></rect>
+                        <rect id="Rectangle" x="8" y="0" width="5" height="14"></rect>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/assets/img/play-icon.svg
+++ b/src/assets/img/play-icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="11px" height="14px" viewBox="0 0 11 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 43.2 (39069) - http://www.bohemiancoding.com/sketch -->
+    <title>play-icon</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="player_v01" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="mvp-paused-signup" transform="translate(-156.000000, -375.000000)" fill="#FFFFFF">
+            <g id="player-control" transform="translate(88.000000, 321.000000)">
+                <g id="slide">
+                    <polygon id="play-icon" points="68 54 68 68 79 61"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/scripts/components/VideoOverlay.js
+++ b/src/scripts/components/VideoOverlay.js
@@ -1,9 +1,12 @@
 /* @flow */
 
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
 import styled from 'styled-components'
 
 import VideoRecord from 'records/VideoRecords'
+import { getIsPlaying } from 'selectors/index'
+import IconButton from 'components/foundations/buttons/IconButton'
 
 import type { Match } from 'react-router-dom'
 
@@ -11,7 +14,9 @@ type Props = {
   video: ?VideoRecord,
   match: Match,
   isEmbed?: boolean,
-  onClick: (e: Object) => void
+  isPlaying: boolean,
+  onClick: (e: Object) => void,
+  togglePlayPause: () => void
 }
 
 type State = {
@@ -31,13 +36,14 @@ const Overlay = styled.div`
   flex-direction: column;
   color: white;
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0));
-  padding: ${overlayPadding};
   box-sizing: border-box;
 `
 
-const TopBar = styled.div`
+const VideoInfo = styled.div`
   display: flex;
   flex-direction: row;
+  flex: 1 0 0;
+  padding: ${overlayPadding};
 `
 
 const Title = styled.div`
@@ -66,6 +72,21 @@ const PopoverWrapper = styled.div`
   height: 110px;
   display: ${props => (props.open ? 'block' : 'none')};
   cursor: default;
+`
+
+const Controls = styled.div`
+  flex: 0 0 50px;
+  display: flex;
+  flex-direction: row;
+  background-color: blue;
+  width: 100%;
+  align-items: center;
+  padding: 0 10px;
+`
+
+const ControlButtonWrapper = styled.div`
+  width: 25px;
+  height: 25px;
 `
 
 class VideoOverlay extends Component<Props, State> {
@@ -131,13 +152,13 @@ class VideoOverlay extends Component<Props, State> {
   }
 
   render () {
-    const { onClick } = this.props
+    const { onClick, isPlaying, togglePlayPause } = this.props
     const { openPopover } = this.state
     const ProfileButton: ?Class<React.Component<any>> = this.state.buttons
       .profile
     return (
       <Overlay data-test-id="video-overlay" onClick={onClick}>
-        <TopBar>
+        <VideoInfo>
           <Title>{this.getVideoTitle()}</Title>
           <ButtonGroup hide={!!this.state.openPopover}>
             {ProfileButton ? (
@@ -155,10 +176,24 @@ class VideoOverlay extends Component<Props, State> {
             open={!!openPopover}
             innerRef={this.popoverWrapperRefCallback}
           />
-        </TopBar>
+        </VideoInfo>
+        <Controls>
+          <ControlButtonWrapper>
+            <IconButton
+              icon={`/assets/img/${isPlaying ? 'pause-icon' : 'play-icon'}.svg`}
+              onClick={togglePlayPause}
+            />
+          </ControlButtonWrapper>
+        </Controls>
       </Overlay>
     )
   }
 }
 
-export default VideoOverlay
+const mapStateToProps = state => ({
+  isPlaying: getIsPlaying(state)
+})
+
+const mapDispatchToProps = dispatch => ({})
+
+export default connect(mapStateToProps, mapDispatchToProps)(VideoOverlay)

--- a/src/scripts/records/PlayerRecords.js
+++ b/src/scripts/records/PlayerRecords.js
@@ -7,11 +7,9 @@ export const _getIsAttemptingPlay = (state: Player): boolean =>
   state.get('isAttemptingPlay')
 
 class Player extends ImmutableRecord({
-  isPlaying: false,
-  isAttemptingPlay: false
+  isPlaying: false
 }) {
   isPlaying: boolean
-  isAttemptingPlay: boolean
 }
 
 export default Player

--- a/src/scripts/reducers/PlayerReducer.js
+++ b/src/scripts/reducers/PlayerReducer.js
@@ -3,21 +3,15 @@
 import { handleActions } from 'redux-actions'
 
 import PlayerRecord from 'records/PlayerRecords'
-import {
-  PLAYER_TOGGLE_PLAYPAUSE,
-  PLAYER_ATTEMPT_PLAY
-} from 'constants/ActionConstants'
+import { PLAYER_TOGGLE_PLAYPAUSE } from 'constants/ActionConstants'
 
 import type { Action } from 'types/ApplicationTypes'
 
 const reducer = {
   [PLAYER_TOGGLE_PLAYPAUSE]: (state: PlayerRecord, action: Action<boolean>) =>
     state.merge({
-      isPlaying: action.payload || !state.get('isPlaying'),
-      isAttemptingPlay: false
-    }),
-  [PLAYER_ATTEMPT_PLAY]: (state: PlayerRecord) =>
-    state.set('isAttemptingPlay', true)
+      isPlaying: action.payload || !state.get('isPlaying')
+    })
 }
 
 export default handleActions(reducer, new PlayerRecord())


### PR DESCRIPTION
**POC**
- this branch shows how we can completely remove the clappr UI elements and use our own
- the controls will be 100% custom, and built w/ `react`
- data flow:
  - `Clappr` still needs to be our original source of truth for the player state
  - When `Clappr` fires a play/pause event, we update our `redux` store accordingly
  - All player elements that need to know about the player state will be connected to the `redux` store and get the state from there. The `Play.js` component will ensure that the clappr player state and `redux` are in sync
  - The state of the media controls, i.e. whether they are shown or hidden, is managed by the `react` state of `Play.js`

Payoff (transitions):

![react controls demo](https://user-images.githubusercontent.com/7697924/36129240-26d2296e-1034-11e8-89cd-2ea7687a7b1c.gif)


☝️ I tried to accomplish this same thing last night with our combination of `Clappr` and react controls, and I could not do it :(. Now, in what I believe was less time, it has been done. Now of course transition are not our priority right now, but we will definitely need them down the line (if not soon).