### PR TITLE
112 - video reducer unit tests (and a few other things)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           command: yarn run server:dev
           background: true
-      - run: yarn run chimp-test
+      - run: node src/scripts/waitForServer.js && yarn run chimp-test
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ jobs:
       - run:
           command: yarn run server:dev
           background: true
-      - run: node src/scripts/waitForServer.js && yarn run chimp-test
+      - run: node src/scripts/waitForServer.js
+      - run: yarn run chimp-test
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then

--- a/.flowconfig
+++ b/.flowconfig
@@ -50,6 +50,8 @@ module.name_mapper='^types\/\(.*\)$' -> '<PROJECT_ROOT>/src/scripts/types/\1'
 module.name_mapper='^types$' -> '<PROJECT_ROOT>/src/scripts/types'
 module.name_mapper='^utils\/\(.*\)$' -> '<PROJECT_ROOT>/src/scripts/utils/\1'
 module.name_mapper='^utils$' -> '<PROJECT_ROOT>/src/scripts/utils'
+module.name_mapper='^unit-tests\/\(.*\)$' -> '<PROJECT_ROOT>/test/unit-tests/\1'
+module.name_mapper='^unit-tests$' -> '<PROJECT_ROOT>/test/unit-tests'
 
 esproposal.class_static_fields=enable
 suppress_type=$FlowIssue

--- a/src/scripts/actions/UploadActions.js
+++ b/src/scripts/actions/UploadActions.js
@@ -4,7 +4,6 @@ import { createAction } from 'redux-actions'
 import paratii from 'utils/ParatiiLib'
 
 import {
-  VIDEOFETCH_SUCCESS,
   UPLOAD_REQUESTED,
   UPLOAD_PROGRESS,
   UPLOAD_SUCCESS,
@@ -17,10 +16,11 @@ import {
   TRANSCODING_SUCCESS,
   TRANSCODING_FAILURE
 } from 'constants/ActionConstants'
+import VideoRecord from 'records/VideoRecords'
+import { videoFetchSuccess } from 'actions/VideoActions'
 
 import type { Dispatch } from 'redux'
 
-const videoFetchSuccess = createAction(VIDEOFETCH_SUCCESS)
 const uploadRequested = createAction(UPLOAD_REQUESTED)
 const uploadProgress = createAction(UPLOAD_PROGRESS)
 const uploadSuccess = createAction(UPLOAD_SUCCESS)
@@ -35,7 +35,7 @@ const transcodingFailure = createAction(TRANSCODING_FAILURE)
 
 export const upload = (file: Object) => (dispatch: Dispatch<*>) => {
   const newVideoId = paratii.eth.vids.makeId()
-  dispatch(videoFetchSuccess({ id: newVideoId }))
+  dispatch(videoFetchSuccess(new VideoRecord({ id: newVideoId })))
   dispatch(selectVideo({ id: newVideoId }))
   dispatch(uploadRequested({ id: newVideoId, filename: file.name }))
   const uploader = paratii.ipfs.uploader.add(file)
@@ -110,7 +110,7 @@ export const saveVideoInfo = (videoInfo: Object) => async (
   if (!videoInfo.id) {
     const newVideoId = paratii.eth.vids.makeId()
     videoInfo.id = newVideoId
-    dispatch(videoFetchSuccess(videoInfo))
+    dispatch(videoFetchSuccess(new VideoRecord(videoInfo)))
   }
   dispatch(videoDataStart(videoInfo))
   console.log('SAVING', videoInfo)

--- a/src/scripts/components/VideoForm.js
+++ b/src/scripts/components/VideoForm.js
@@ -187,7 +187,7 @@ class VideoForm extends Component<Props, Object> {
     const thumbImages =
       video &&
       video.getIn(['transcodingStatus', 'data', 'sizes', 'screenshots'])
-    const ipfsHash = video && video.get('ipfsHash')
+    const ipfsHash = (video && video.get('ipfsHash')) || ''
     let thumbImage = ''
     if (thumbImages) {
       thumbImage = `https://gateway.paratii.video/ipfs/${ipfsHash}/${thumbImages.get(

--- a/src/scripts/constants/ActionConstants.js
+++ b/src/scripts/constants/ActionConstants.js
@@ -6,7 +6,6 @@ const createActionConstant = constant => `@@PARATII_PORTAL_${constant}`
 export const INITIALIZE = createActionConstant('INITIALIZE')
 
 /* Video actions */
-export const VIDEO_LOADED = createActionConstant('VIDEO_LOADED')
 export const VIDEO_SELECT = createActionConstant('VIDEO_SELECT')
 export const VIDEOFETCH_ERROR = createActionConstant('VIDEOFETCH_ERROR')
 export const VIDEOFETCH_SUCCESS = createActionConstant('VIDEOFETCH_SUCCESS')

--- a/src/scripts/containers/VideoManagerContainer.js
+++ b/src/scripts/containers/VideoManagerContainer.js
@@ -53,7 +53,7 @@ class VideoManagerContainer extends Component<Props, void> {
 
     return (
       <CardContainer>
-        {selectedVideo !== null ? (
+        {selectedVideo ? (
           <Card
             margin="0 25px 0 0"
             nopadding
@@ -69,13 +69,9 @@ class VideoManagerContainer extends Component<Props, void> {
           <UploadFile />
         )}
 
-        {selectedVideo !== null ? (
-          <VideoForm />
-        ) : (
-          <RedeemVoucher margin="0 25px" />
-        )}
+        {selectedVideo ? <VideoForm /> : <RedeemVoucher margin="0 25px" />}
 
-        {selectedVideo === null && <PTIGuide />}
+        {!selectedVideo && <PTIGuide />}
       </CardContainer>
     )
   }

--- a/src/scripts/records/VideoRecords.js
+++ b/src/scripts/records/VideoRecords.js
@@ -3,23 +3,24 @@
 import { Record as ImmutableRecord } from 'immutable'
 import { AsyncTaskStatusRecord } from 'records/AsyncTaskStatusRecord'
 
-class Video extends ImmutableRecord({
-  description: '',
-  filename: null,
-  id: '',
-  ipfsData: '',
-  ipfsHashOrig: '',
-  ipfsHash: '',
-  owner: '',
-  price: '',
-  thumbnailUrl: '',
-  title: '',
-  blockchainStatus: new AsyncTaskStatusRecord(),
-  transcodingStatus: new AsyncTaskStatusRecord(),
-  uploadStatus: new AsyncTaskStatusRecord(),
-  fetchStatus: new AsyncTaskStatusRecord(),
-  url: ''
-}) {
+class Video
+  extends ImmutableRecord({
+    description: '',
+    filename: null,
+    id: '',
+    ipfsData: '',
+    ipfsHashOrig: '',
+    ipfsHash: '',
+    owner: '',
+    price: '',
+    thumbnailUrl: '',
+    title: '',
+    blockchainStatus: new AsyncTaskStatusRecord(),
+    transcodingStatus: new AsyncTaskStatusRecord(),
+    uploadStatus: new AsyncTaskStatusRecord(),
+    fetchStatus: new AsyncTaskStatusRecord(),
+    url: ''
+  }) {
   description: string
   filename: string
   id: string

--- a/src/scripts/reducers/VideosReducer.js
+++ b/src/scripts/reducers/VideosReducer.js
@@ -232,14 +232,15 @@ const reducer = {
     if (!payload || !payload.id) {
       return state
     }
-    return state.mergeDeep({
-      [payload.id]: new VideoRecord({
+    return state.set(
+      payload.id,
+      new VideoRecord({
         fetchStatus: new AsyncTaskStatusRecord({
           name: 'failed',
           data: new DataStatusRecord({ error: payload.error.message })
         })
       })
-    })
+    )
   },
   [VIDEOFETCH_SUCCESS]: (
     state: VideoRecordMap,

--- a/src/scripts/reducers/VideosReducer.js
+++ b/src/scripts/reducers/VideosReducer.js
@@ -211,15 +211,23 @@ const reducer = {
     state: VideoRecordMap,
     { payload }: Action<VideoRecord>
   ): VideoRecordMap => {
-    return state.setIn([payload.id, 'transcodingStatus'], {
-      name: 'failed',
-      data: {}
-    })
+    if (!payload || !payload.id || !state.get(payload.id)) {
+      return state
+    }
+    return state.setIn(
+      [payload.id, 'transcodingStatus'],
+      new AsyncTaskStatusRecord({
+        name: 'failed'
+      })
+    )
   },
   [VIDEO_LOADED]: (
     state: VideoRecordMap,
     { payload }: Action<VideoRecord>
   ): VideoRecordMap => {
+    if (!payload || !payload.get('id')) {
+      return state
+    }
     return state.set(payload.get('id'), payload)
   },
   [VIDEOFETCH_ERROR]: (

--- a/src/scripts/reducers/VideosReducer.js
+++ b/src/scripts/reducers/VideosReducer.js
@@ -53,13 +53,10 @@ const reducer = {
     if (!payload || !state.get(payload.id)) {
       throw Error(`Unknown id: ${(payload && payload.id) || 'undefined'}`)
     }
-    return state.mergeDeep({
-      [payload.id]: {
-        uploadStatus: {
-          data: { progress: payload.progress }
-        }
-      }
-    })
+    return state.setIn(
+      [payload.id, 'uploadStatus', 'data', 'progress'],
+      payload.progress
+    )
   },
   [UPLOAD_LOCAL_SUCCESS]: (
     state: VideoRecordMap,
@@ -69,18 +66,20 @@ const reducer = {
       throw Error(`Unknown id: ${(payload && payload.id) || 'undefined'}`)
     }
     const ipfsHashOrig = payload.hash
-    state = state.mergeDeep({
-      [payload.id]: {
-        ipfsHashOrig: ipfsHashOrig,
-        uploadStatus: {
-          name: 'uploaded to local node',
-          data: {
-            ipfsHashOrig: ipfsHashOrig
-          }
-        }
+    return state.withMutations(
+      (mutableState: VideoRecordMap): VideoRecordMap => {
+        mutableState.setIn([payload.id, 'ipfsHashOrig'], ipfsHashOrig)
+        mutableState.setIn(
+          [payload.id, 'uploadStatus', 'name'],
+          'uploaded to local node'
+        )
+        mutableState.setIn(
+          [payload.id, 'uploadStatus', 'data', 'ipfsHashOrig'],
+          ipfsHashOrig
+        )
+        return mutableState
       }
-    })
-    return state
+    )
   },
   [UPLOAD_SUCCESS]: (
     state: VideoRecordMap,
@@ -90,17 +89,20 @@ const reducer = {
       throw Error(`Unknown id: ${(payload && payload.id) || 'undefined'}`)
     }
     const ipfsHashOrig = payload.hash
-    return state.mergeDeep({
-      [payload.id]: {
-        ipfsHashOrig: ipfsHashOrig,
-        uploadStatus: {
-          name: 'uploaded to transcoder node',
-          data: {
-            ipfsHashOrig: ipfsHashOrig
-          }
-        }
+    return state.withMutations(
+      (mutableState: VideoRecordMap): VideoRecordMap => {
+        mutableState.setIn([payload.id, 'ipfsHashOrig'], ipfsHashOrig)
+        mutableState.setIn(
+          [payload.id, 'uploadStatus', 'name'],
+          'uploaded to transcoder node'
+        )
+        mutableState.setIn(
+          [payload.id, 'uploadStatus', 'data', 'ipfsHashOrig'],
+          ipfsHashOrig
+        )
+        return mutableState
       }
-    })
+    )
   },
   [UPDATE_VIDEO_INFO]: (
     state: VideoRecordMap,

--- a/src/scripts/reducers/VideosReducer.js
+++ b/src/scripts/reducers/VideosReducer.js
@@ -208,7 +208,7 @@ const reducer = {
         name: 'success',
         data: new DataStatusRecord({
           ipfsHash,
-          sizes: Immutable.Map(payload.sizes)
+          sizes: Immutable.fromJS(payload.sizes)
         })
       })
     )

--- a/src/scripts/waitForServer.js
+++ b/src/scripts/waitForServer.js
@@ -1,0 +1,27 @@
+const http = require('http')
+
+const pingServer = () => {
+  const req = http.request(
+    {
+      hostname: 'localhost',
+      port: 8080,
+      path: '/',
+      method: 'GET'
+    },
+    res => {
+      if (res.statusCode === 200) {
+        process.exit(0)
+      } else {
+        console.error(
+          `ERROR: Dev server returned status code of ${res.statusCode}`
+        )
+        process.exit(1)
+      }
+    }
+  )
+
+  req.on('error', pingServer)
+  req.end()
+}
+
+pingServer()

--- a/test/functional-tests/player.test.js
+++ b/test/functional-tests/player.test.js
@@ -89,7 +89,7 @@ describe('Player:', function () {
       browser.url(`http://localhost:8080/play/${videoId}`)
       browser.waitUntilVideoIsPlaying()
     })
-    it('video not found @watch', () => {
+    it('video not found', () => {
       browser.url(`http://localhost:8080/play/xxx`)
       browser.waitForText('main h1', '404 - Oooooops, page not found')
     })

--- a/test/functional-tests/uploader.spec.js
+++ b/test/functional-tests/uploader.spec.js
@@ -2,7 +2,7 @@ import { assert } from 'chai'
 import { paratii } from './test-utils/helpers'
 
 describe('Uploader Tool', function () {
-  it('should have basic flow in place @watch', async function () {
+  it('should have basic flow in place', async function () {
     // see https://github.com/Paratii-Video/paratii-portal/issues/8
     const video = {
       title: 'Some title',

--- a/test/functional-tests/uploader.spec.js
+++ b/test/functional-tests/uploader.spec.js
@@ -54,8 +54,7 @@ describe('Uploader Tool', function () {
 
     // now wait until the transcoder is done - we should see a "play" link at this point
     // TODO: this often times out on circleci because it depends on the (external) response of the transcoder
-    await browser.waitForExist(`a[href="/play/${videoId}"]`)
-    await browser.click(`a[href="/play/${videoId}"]`)
+    browser.waitAndClick(`a[href="/play/${videoId}"]`)
   })
 
   it.skip('cancel upload should work [but is not yet]', function () {

--- a/test/functional-tests/uploader.spec.js
+++ b/test/functional-tests/uploader.spec.js
@@ -54,7 +54,7 @@ describe('Uploader Tool', function () {
 
     // now wait until the transcoder is done - we should see a "play" link at this point
     // TODO: this often times out on circleci because it depends on the (external) response of the transcoder
-    browser.waitAndClick(`a[href="/play/${videoId}"]`)
+    await browser.waitAndClick(`a[href="/play/${videoId}"]`)
   })
 
   it.skip('cancel upload should work [but is not yet]', function () {

--- a/test/unit-tests/fixtures/VideoFixtures.js
+++ b/test/unit-tests/fixtures/VideoFixtures.js
@@ -1,0 +1,34 @@
+export const getDefaultDataStatus = () => ({
+  id: '',
+  title: '',
+  description: '',
+  owner: '',
+  ipfsHash: '',
+  ipfsHashOrig: '',
+  sizes: '',
+  progress: '',
+  error: ''
+})
+
+export const getDefaultAsyncTaskStatus = () => ({
+  name: 'idle',
+  data: getDefaultDataStatus()
+})
+
+export const getDefaultVideo = () => ({
+  description: '',
+  filename: null,
+  id: '',
+  ipfsData: '',
+  ipfsHashOrig: '',
+  ipfsHash: '',
+  owner: '',
+  price: '',
+  thumbnailUrl: '',
+  title: '',
+  blockchainStatus: getDefaultAsyncTaskStatus(),
+  transcodingStatus: getDefaultAsyncTaskStatus(),
+  uploadStatus: getDefaultAsyncTaskStatus(),
+  fetchStatus: getDefaultAsyncTaskStatus(),
+  url: ''
+})

--- a/test/unit-tests/reducers/VideosReducer.test.js
+++ b/test/unit-tests/reducers/VideosReducer.test.js
@@ -1,0 +1,855 @@
+import { createStore } from 'redux'
+import Immutable from 'immutable'
+
+import reducer from 'reducers/VideosReducer'
+import {
+  UPLOAD_REQUESTED,
+  UPLOAD_PROGRESS,
+  UPLOAD_SUCCESS,
+  UPLOAD_LOCAL_SUCCESS,
+  UPDATE_VIDEO_INFO,
+  VIDEO_DATA_START,
+  VIDEO_DATA_SAVED,
+  VIDEO_LOADED,
+  TRANSCODING_REQUESTED,
+  TRANSCODING_PROGRESS,
+  TRANSCODING_SUCCESS,
+  TRANSCODING_FAILURE,
+  VIDEOFETCH_ERROR,
+  VIDEOFETCH_SUCCESS
+} from 'constants/ActionConstants'
+import VideoRecord from 'records/VideoRecords'
+import {
+  AsyncTaskStatusRecord,
+  DataStatusRecord
+} from 'records/AsyncTaskStatusRecord'
+import {
+  getDefaultVideo,
+  getDefaultAsyncTaskStatus,
+  getDefaultDataStatus
+} from 'unit-tests/fixtures/VideoFixtures'
+
+describe.only('Video Reducer', () => {
+  describe('UPLOAD_REQUESTED', () => {
+    it('should do nothing if there is no payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      store.dispatch({
+        type: UPLOAD_REQUESTED
+      })
+      expect(store.getState().toJS()).to.deep.equal({})
+    })
+    it('should do nothing if there is no id in the payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      store.dispatch({
+        type: UPLOAD_REQUESTED,
+        payload: {
+          foo: 'bar'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({})
+    })
+    it('should add a video if there are no videos in the store', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      store.dispatch({
+        type: UPLOAD_REQUESTED,
+        payload: {
+          id: '111',
+          filename: 'bazbar.mp4'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '111': {
+          ...getDefaultVideo(),
+          filename: 'bazbar.mp4',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'running',
+            data: {
+              ...getDefaultDataStatus(),
+              progress: 0
+            }
+          }
+        }
+      })
+    })
+    it('should add a video to the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({
+            filename: 'bazbar'
+          }),
+          '333': new VideoRecord({
+            title: 'beezle'
+          })
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': {
+          ...getDefaultVideo(),
+          filename: 'bazbar'
+        },
+        '333': {
+          ...getDefaultVideo(),
+          title: 'beezle'
+        }
+      })
+      store.dispatch({
+        type: UPLOAD_REQUESTED,
+        payload: {
+          id: '111',
+          filename: 'bazbar.mp4'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': {
+          ...getDefaultVideo(),
+          filename: 'bazbar'
+        },
+        '333': {
+          ...getDefaultVideo(),
+          title: 'beezle'
+        },
+        '111': {
+          ...getDefaultVideo(),
+          filename: 'bazbar.mp4',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'running',
+            data: {
+              ...getDefaultDataStatus(),
+              progress: 0
+            }
+          }
+        }
+      })
+    })
+    it('should add update an existing video in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({
+            filename: 'bazbar'
+          }),
+          '333': new VideoRecord({
+            title: 'beezle'
+          }),
+          '111': new VideoRecord({
+            title: 'test123',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'running',
+              data: new DataStatusRecord({
+                title: 'foo'
+              })
+            })
+          })
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': {
+          ...getDefaultVideo(),
+          filename: 'bazbar'
+        },
+        '333': {
+          ...getDefaultVideo(),
+          title: 'beezle'
+        },
+        '111': {
+          ...getDefaultVideo(),
+          title: 'test123',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'running',
+            data: {
+              ...getDefaultDataStatus(),
+              title: 'foo'
+            }
+          }
+        }
+      })
+      store.dispatch({
+        type: UPLOAD_REQUESTED,
+        payload: {
+          id: '111',
+          filename: 'bazbar.mp4'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': {
+          ...getDefaultVideo(),
+          filename: 'bazbar'
+        },
+        '333': {
+          ...getDefaultVideo(),
+          title: 'beezle'
+        },
+        '111': {
+          ...getDefaultVideo(),
+          title: 'test123',
+          filename: 'bazbar.mp4',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'running',
+            data: {
+              ...getDefaultDataStatus(),
+              progress: 0,
+              title: 'foo'
+            }
+          }
+        }
+      })
+    })
+  })
+  describe('UPLOAD_PROGRESS', () => {
+    it('should throw if there is no payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      expect(() =>
+        store.dispatch({
+          type: UPLOAD_PROGRESS
+        })
+      ).to.throw()
+    })
+    it('should throw when there is no id in the payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      expect(() =>
+        store.dispatch({
+          type: UPLOAD_PROGRESS,
+          payload: {
+            foo: 'bar'
+          }
+        })
+      ).to.throw()
+    })
+    it('should throw when there is no matching id in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+      expect(() =>
+        store.dispatch({
+          type: UPLOAD_PROGRESS,
+          payload: {
+            id: '111'
+          }
+        })
+      ).to.throw()
+    })
+    it('should update the video progress when a matching id is in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '888': new VideoRecord({
+            title: 'foobar',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'running',
+              data: new DataStatusRecord({
+                title: 'foo',
+                progress: 44
+              })
+            })
+          }),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'running',
+            data: {
+              ...getDefaultDataStatus(),
+              title: 'foo',
+              progress: 44
+            }
+          }
+        },
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: UPLOAD_PROGRESS,
+        payload: {
+          id: '888',
+          progress: 98
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'running',
+            data: {
+              ...getDefaultDataStatus(),
+              title: 'foo',
+              progress: 98
+            }
+          }
+        },
+        '999': getDefaultVideo()
+      })
+    })
+  })
+  describe('UPLOAD_LOCAL_SUCCESS', () => {
+    it('should throw if there is no payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      expect(() =>
+        store.dispatch({
+          type: UPLOAD_LOCAL_SUCCESS
+        })
+      ).to.throw()
+    })
+    it('should throw when there is no id in the payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      expect(() =>
+        store.dispatch({
+          type: UPLOAD_LOCAL_SUCCESS,
+          payload: {
+            foo: 'bar'
+          }
+        })
+      ).to.throw()
+    })
+    it('should throw when there is no matching id in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+      expect(() =>
+        store.dispatch({
+          type: UPLOAD_LOCAL_SUCCESS,
+          payload: {
+            id: '111'
+          }
+        })
+      ).to.throw()
+    })
+    it('should update the upload status and hash when a matching id is in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '888': new VideoRecord({
+            title: 'foobar',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'running',
+              data: new DataStatusRecord({
+                title: 'foo',
+                progress: 44
+              })
+            })
+          }),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'running',
+            data: {
+              ...getDefaultDataStatus(),
+              title: 'foo',
+              progress: 44
+            }
+          }
+        },
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: UPLOAD_LOCAL_SUCCESS,
+        payload: {
+          id: '888',
+          hash: 'Qjow875hgaahaw'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          ipfsHashOrig: 'Qjow875hgaahaw',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to local node',
+            data: {
+              ...getDefaultDataStatus(),
+              title: 'foo',
+              progress: 44,
+              ipfsHashOrig: 'Qjow875hgaahaw'
+            }
+          }
+        },
+        '999': getDefaultVideo()
+      })
+    })
+  })
+  describe('UPLOAD_SUCCESS', () => {
+    it('should throw if there is no payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      expect(() =>
+        store.dispatch({
+          type: UPLOAD_SUCCESS
+        })
+      ).to.throw()
+    })
+    it('should throw when there is no id in the payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      expect(() =>
+        store.dispatch({
+          type: UPLOAD_SUCCESS,
+          payload: {
+            foo: 'bar'
+          }
+        })
+      ).to.throw()
+    })
+    it('should throw when there is no matching id in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+      expect(() =>
+        store.dispatch({
+          type: UPLOAD_SUCCESS,
+          payload: {
+            id: '111'
+          }
+        })
+      ).to.throw()
+    })
+    it('should update the upload status and hash when a matching id is in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '888': new VideoRecord({
+            title: 'foobar',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'uploaded to local node',
+              data: new DataStatusRecord({
+                title: 'foo',
+                progress: 44
+              })
+            })
+          }),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to local node',
+            data: {
+              ...getDefaultDataStatus(),
+              title: 'foo',
+              progress: 44
+            }
+          }
+        },
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: UPLOAD_SUCCESS,
+        payload: {
+          id: '888',
+          hash: 'Qjow875hgaahaw'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          ipfsHashOrig: 'Qjow875hgaahaw',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node',
+            data: {
+              ...getDefaultDataStatus(),
+              title: 'foo',
+              progress: 44,
+              ipfsHashOrig: 'Qjow875hgaahaw'
+            }
+          }
+        },
+        '999': getDefaultVideo()
+      })
+    })
+  })
+  describe('UPDATE_VIDEO_INFO', () => {
+    it('should do nothing if there is no payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      store.dispatch({
+        type: UPDATE_VIDEO_INFO
+      })
+      expect(store.getState().toJS()).to.deep.equal({})
+    })
+    it('should do nothing when there is no id in the payload', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '999': new VideoRecord()
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: UPDATE_VIDEO_INFO,
+        payload: {
+          foo: 'bar'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+    })
+    it('should do nothing when there is no matching id in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: UPDATE_VIDEO_INFO,
+        payload: {
+          id: '111'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+    })
+    it('should update the title and description of an existing video', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '888': new VideoRecord({
+            title: 'foobar',
+            description: 'great video',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'uploaded to transcoder node'
+            })
+          }),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          }
+        },
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: UPDATE_VIDEO_INFO,
+        payload: {
+          id: '888',
+          title: 'bazbar',
+          description: 'even better description'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'bazbar',
+          description: 'even better description',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          }
+        },
+        '999': getDefaultVideo()
+      })
+    })
+  })
+  describe('VIDEO_DATA_START', () => {
+    it('should do nothing if there is no payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      store.dispatch({
+        type: VIDEO_DATA_START
+      })
+      expect(store.getState().toJS()).to.deep.equal({})
+    })
+    it('should do nothing when there is no id in the payload', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '999': new VideoRecord()
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: VIDEO_DATA_START,
+        payload: {
+          foo: 'bar'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+    })
+    it('should do nothing when there is no matching id in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: VIDEO_DATA_START,
+        payload: {
+          id: '111'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+    })
+    it('should update the blockchain status of the matching video in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '888': new VideoRecord({
+            title: 'foobar',
+            description: 'great video',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'uploaded to transcoder node'
+            })
+          }),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          }
+        },
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: VIDEO_DATA_START,
+        payload: {
+          id: '888',
+          title: 'bazbar',
+          description: 'foobaz',
+          owner: 'me'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          },
+          blockchainStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'running',
+            data: {
+              ...getDefaultDataStatus(),
+              id: '888',
+              title: 'bazbar',
+              description: 'foobaz',
+              owner: 'me'
+            }
+          }
+        },
+        '999': getDefaultVideo()
+      })
+    })
+  })
+  describe.only('VIDEO_DATA_SAVED', () => {
+    it('should do nothing if there is no payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      store.dispatch({
+        type: VIDEO_DATA_SAVED
+      })
+      expect(store.getState().toJS()).to.deep.equal({})
+    })
+    it('should do nothing when there is no id in the payload', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '999': new VideoRecord()
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: VIDEO_DATA_SAVED,
+        payload: {
+          foo: 'bar'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+    })
+    it('should do nothing when there is no matching id in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: VIDEO_DATA_SAVED,
+        payload: {
+          id: '111'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+    })
+    it('should update the blockchain status and data of the matching video in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '888': new VideoRecord({
+            title: 'foobar',
+            description: 'great video',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'uploaded to transcoder node'
+            })
+          }),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          }
+        },
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: VIDEO_DATA_SAVED,
+        payload: {
+          id: '888',
+          title: 'bazbar',
+          description: 'foobaz',
+          owner: 'me'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'bazbar',
+          description: 'foobaz',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          },
+          blockchainStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'success',
+            data: {
+              ...getDefaultDataStatus(),
+              id: '888',
+              title: 'bazbar',
+              description: 'foobaz',
+              owner: 'me'
+            }
+          }
+        },
+        '999': getDefaultVideo()
+      })
+    })
+  })
+})

--- a/test/unit-tests/reducers/VideosReducer.test.js
+++ b/test/unit-tests/reducers/VideosReducer.test.js
@@ -737,7 +737,7 @@ describe.only('Video Reducer', () => {
       })
     })
   })
-  describe.only('VIDEO_DATA_SAVED', () => {
+  describe('VIDEO_DATA_SAVED', () => {
     it('should do nothing if there is no payload', () => {
       const store = createStore(reducer)
       expect(store.getState().toJS()).to.deep.equal({})
@@ -849,6 +849,287 @@ describe.only('Video Reducer', () => {
           }
         },
         '999': getDefaultVideo()
+      })
+    })
+  })
+  describe('TRANSCODING_REQUESTED', () => {
+    it('should do nothing if there is no payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      store.dispatch({
+        type: TRANSCODING_REQUESTED
+      })
+      expect(store.getState().toJS()).to.deep.equal({})
+    })
+    it('should do nothing when there is no id in the payload', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '999': new VideoRecord()
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: TRANSCODING_REQUESTED,
+        payload: {
+          foo: 'bar'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+    })
+    it('should do nothing when there is no matching id in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: TRANSCODING_REQUESTED,
+        payload: {
+          id: '111'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+    })
+    it('should update the transcoding status of the matching video in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({}),
+          '888': new VideoRecord({
+            title: 'foobar',
+            description: 'great video',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'uploaded to transcoder node'
+            })
+          })
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          }
+        }
+      })
+      store.dispatch({
+        type: TRANSCODING_REQUESTED,
+        payload: {
+          id: '888'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          },
+          transcodingStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'requested',
+            data: {
+              ...getDefaultDataStatus()
+            }
+          }
+        }
+      })
+    })
+  })
+  describe.only('TRANSCODING_SUCCESS', () => {
+    it('should do nothing if there is no payload', () => {
+      const store = createStore(reducer)
+      expect(store.getState().toJS()).to.deep.equal({})
+      store.dispatch({
+        type: TRANSCODING_SUCCESS
+      })
+      expect(store.getState().toJS()).to.deep.equal({})
+    })
+    it('should do nothing when there is no id in the payload', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '999': new VideoRecord()
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: TRANSCODING_SUCCESS,
+        payload: {
+          foo: 'bar'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '999': getDefaultVideo()
+      })
+    })
+    it('should do nothing when there is no matching id in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({})
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+      store.dispatch({
+        type: TRANSCODING_SUCCESS,
+        payload: {
+          id: '111'
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo()
+      })
+    })
+    it('should do nothing if the payload is missing the "master" property', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({}),
+          '888': new VideoRecord({
+            title: 'foobar',
+            description: 'great video',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'uploaded to transcoder node'
+            })
+          })
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          }
+        }
+      })
+      store.dispatch({
+        type: TRANSCODING_SUCCESS,
+        payload: {
+          id: '888',
+          sizes: {
+            foo: {
+              hash: 'q82gh20'
+            }
+          }
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          }
+        }
+      })
+    })
+    it('should update the transcoding status of the matching video in the store', () => {
+      const store = createStore(
+        reducer,
+        Immutable.Map({
+          '123': new VideoRecord({}),
+          '999': new VideoRecord({}),
+          '888': new VideoRecord({
+            title: 'foobar',
+            description: 'great video',
+            uploadStatus: new AsyncTaskStatusRecord({
+              name: 'uploaded to transcoder node'
+            })
+          })
+        })
+      )
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          }
+        }
+      })
+      store.dispatch({
+        type: TRANSCODING_SUCCESS,
+        payload: {
+          id: '888',
+          sizes: {
+            master: {
+              hash: 'q82gh20'
+            }
+          }
+        }
+      })
+      expect(store.getState().toJS()).to.deep.equal({
+        '123': getDefaultVideo(),
+        '999': getDefaultVideo(),
+        '888': {
+          ...getDefaultVideo(),
+          title: 'foobar',
+          description: 'great video',
+          ipfsHash: 'q82gh20',
+          uploadStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'uploaded to transcoder node'
+          },
+          transcodingStatus: {
+            ...getDefaultAsyncTaskStatus(),
+            name: 'success',
+            data: {
+              ...getDefaultDataStatus(),
+              ipfsHash: 'q82gh20',
+              sizes: {
+                master: {
+                  hash: 'q82gh20'
+                }
+              }
+            }
+          }
+        }
       })
     })
   })


### PR DESCRIPTION
**Work Done**
- add unit tests for all actions handled by the videos reducer
- remove a reducer path that wasn't being used
- change/fix some logic in the reducers (with a focus on ensuring edge cases are covered and that the whole state remains immutable)
- add a scripts/configure circle so that chimp tests do not start until dev server is responsive

@jellegerbrandy I changed code in all of the video reducer code paths, so feel free to do some testing to make sure nothing is screwed up. I do not know the uploader as well at this point to be able to tell for sure that things are working 100% as designed. (Also I think the transcoder is still not working so difficult to test the entire workflow).

Resolves #112, #160, and #166 