### PR TITLE
Fix clappr dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4388,9 +4388,9 @@
       }
     },
     "clappr": {
-      "version": "0.2.86",
-      "resolved": "https://registry.npmjs.org/clappr/-/clappr-0.2.86.tgz",
-      "integrity": "sha512-txGZhSbKZI02+ASZL136qQE7+kv8kIO9WNh/ZfeTHZWFPTL7sRInQNlqAnMGFt0FW7+++P579vjJwoZ/+OGsAw=="
+      "version": "0.2.78",
+      "resolved": "https://registry.npmjs.org/clappr/-/clappr-0.2.78.tgz",
+      "integrity": "sha512-gJHhNn3WQcmoWhwl1wUIfg3ktoTcKgpuQiVvIjyEA0tJsVB4wCYtsh3JRrOYLC2hF5fEbnfwgElls8PlyMc16g=="
     },
     "class-utils": {
       "version": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
-    "clappr": "^0.2.78",
+    "clappr": "0.2.78",
     "hlsjs-ipfs-loader": "github:ya7ya/hlsjs-ipfs-loader#bd890b9e78f2c273fcb1dc4e1d43ad0afc69558c",
     "immutable": "^3.8.2",
     "ipfs": "github:ya7ya/js-ipfs#paratii/v0.27.6",


### PR DESCRIPTION
We accidentally saved a `package-lock.json` w/ an upgraded, backwards incompatible version of clappr. Fixing here

cc @jellegerbrandy 