### PR TITLE
Fix embed route

### DIFF
--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -19,11 +19,11 @@ exports.player = async function player (req, res, next) {
   const { id } = req.params
   const path = req.route.path
   const video = await paratii.core.vids.get(id)
-  const meta = ''
 
   res.render('index', {
     player: true,
     video: video,
+    embed: path === '/embed/:id',
     helpers: {
       title: function () {
         if (video !== null) {
@@ -53,19 +53,6 @@ exports.player = async function player (req, res, next) {
       },
       embedUrl: function () {
         return 'https://portal.paratii.video/embed/' + video._id
-      },
-      meta: function () {
-        return meta
-      },
-      embed: function () {
-        return path === '/embed/:id'
-      },
-      script: function () {
-        if (path === '/embed/:id') {
-          return '<script type="text/javascript" src="/embed/bundle.js"></script>'
-        } else if (path === '/video/:id') {
-          return '<script type="text/javascript" src="/bundle.js"></script>'
-        }
       }
     }
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,16 +102,7 @@ const config = {
       {
         test: /\.scss$/,
         include: stylesDir,
-        exclude: stylesDir + "/embed/index.scss",
         use: ["style-loader", "css-loader", "postcss-loader", "sass-loader"]
-      },
-      {
-        test: /\.scss$/,
-        include: stylesDir + "/embed/index.scss",
-        use: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
-          use: ['css-loader', 'sass-loader']
-        })
       }
     ]
   },


### PR DESCRIPTION
**Problem**
- `/embed/:id` was loading the regular portal, not the specialized embed route. And once it got there you always saw `404`

**Work Done**
- fix how embed param was passed to template
- fix embed styles processing

@geckoslair could you do some testing to make sure this is all good? My fix works at a high level but if you can make sure all of the partials are rendering as expected that would be great 😄 