### PR TITLE
345 - initialize volume correctly

### DIFF
--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -465,6 +465,7 @@ class Play extends Component<Props, State> {
   }
 
   createPlayer = (video: VideoRecord): void => {
+    const { updateVolume } = this.props
     if (this.player && this.player.destroy) {
       this.player.destroy()
     }
@@ -489,6 +490,10 @@ class Play extends Component<Props, State> {
         autoPlay: true
       })
       this.bindClapprEvents()
+
+      if (this.player) {
+        updateVolume(this.player.getVolume())
+      }
 
       // initialize mux here
       // Note to frontend ppl. if there is a better locations for this

--- a/src/scripts/types/ApplicationTypes.js
+++ b/src/scripts/types/ApplicationTypes.js
@@ -74,6 +74,7 @@ export type ClapprPlayer = EventEmitter & {
   pause: () => void,
   mute: () => void,
   unmute: () => void,
+  getVolume: () => number,
   setVolume: (percentage: number) => void,
   destroy: () => void,
   seek: (time: number) => void


### PR DESCRIPTION
**Issue**
#345 

**Problem**
Volume always starts at `0` on page load

**Work Done**
Set volume in `redux` when player is created


**Demo**

![volumewin](https://user-images.githubusercontent.com/7697924/37374704-b448a5fa-26f2-11e8-8caf-b97c4794d917.gif)

