### PR TITLE
Description height - fixed #354  - Sharing overlay opacity - solved #359

### DIFF
--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -123,7 +123,7 @@ const ShareOverlay = styled.div`
   height: 100%;
   justify-content: center;
   left: 0;
-  opacity: ${props => (props.show ? 1 : 0)};
+  opacity: ${props => (props.show ? 0.9 : 0)};
   position: absolute;
   pointer-events: ${props => (!props.show ? 'none' : null)};
   transition: opacity ${props => props.theme.animation.time.repaint};

--- a/src/scripts/components/widgets/forms/TextareaField.js
+++ b/src/scripts/components/widgets/forms/TextareaField.js
@@ -55,12 +55,12 @@ const HelperLabel = styled.span`
 `
 
 class TextareaField extends Component<Props, void> {
-  constructor (props) {
+  constructor (props: Props) {
     super(props)
 
     this.state = {
-      filled: this.props.value ? this.props.value.length > 0 : false,
-      value: this.props.value
+      filled: props.value ? props.value.length > 0 : false,
+      value: props.value
     }
 
     this.handleHeight = this.handleHeight.bind(this)
@@ -103,6 +103,10 @@ class TextareaField extends Component<Props, void> {
     if (this.props.readonly) {
       e.target.select()
     }
+  }
+
+  componentDidMount (): void {
+    this.handleHeight()
   }
 
   componentWillReceiveProps (nextProps: Props): void {

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -4,11 +4,6 @@ html, body, #root {
   width: 100%;
 }
 
-#root {
-  overflow-x: hidden;
-  overflow-y: scroll;
-}
-
 .full-block {
   display: block;
   height: 100%;


### PR DESCRIPTION
- Description height
https://github.com/paratii-video/paratii-portal/issues/354
Handling the text area height when `componentDidMount`



- Sharing overlay opacity settings (make more transparent) #359
https://github.com/Paratii-Video/paratii-portal/issues/359

@pedrocasa I've set the opacity to `0.9`