### PR TITLE
366 - refresh token balances after voucher redemption

### DIFF
--- a/src/scripts/components/widgets/RedeemVoucher.js
+++ b/src/scripts/components/widgets/RedeemVoucher.js
@@ -8,6 +8,7 @@ import Text from '../foundations/Text'
 import Card from '../structures/Card'
 
 type Props = {
+  loadBalances: () => void,
   notification: (Object, string) => void
 }
 
@@ -56,6 +57,7 @@ class RedeemVoucher extends Component<Props, Object> {
   }
 
   redeemVoucher (event: Object) {
+    const { loadBalances } = this.props
     event.preventDefault()
     this.setState({ disableInput: true, error: '' })
     this.props.notification({ title: 'Reading' }, 'warning')
@@ -63,6 +65,7 @@ class RedeemVoucher extends Component<Props, Object> {
     paratii.eth.vouchers
       .redeem(voucherCode)
       .then(resp => {
+        loadBalances()
         const amount = String(resp)
         this.props.notification(
           { title: 'Success', message: `You have earned ${amount} PTI.` },

--- a/src/scripts/containers/RedeemVoucherContainer.js
+++ b/src/scripts/containers/RedeemVoucherContainer.js
@@ -1,15 +1,18 @@
 /* @flow */
 
 import { connect } from 'react-redux'
-import type { RootState } from 'types/ApplicationTypes'
 import { bindActionCreators } from 'redux'
-import RedeemVoucher from 'components/widgets/RedeemVoucher'
-
 import { show } from 'react-notification-system-redux'
+
+import RedeemVoucher from 'components/widgets/RedeemVoucher'
+import { loadBalances } from 'actions/UserActions'
+
+import type { RootState } from 'types/ApplicationTypes'
 
 const mapStateToProps = (state: RootState) => ({})
 
 const mapDispatchToProps = dispatch => ({
+  loadBalances: bindActionCreators(loadBalances, dispatch),
   notification: bindActionCreators(show, dispatch)
 })
 


### PR DESCRIPTION
**Issue**
#366 

**Problem**
After redeeming PTI via a voucher, the balance in the nav bar does not update after either 3 minutes have passed or the user reload the page. This is not ideal!

**Work Done**
Trigger a balance update once the voucher has been redeemed. 

**Note**
~~I do not have a voucher code to test this with so if someone could send me one that would be great 😄~~
☝️ I got some vouchers, tested, and it works