### PR TITLE
Prevent super tall video manager

### DIFF
--- a/src/scripts/components/VideoList.js
+++ b/src/scripts/components/VideoList.js
@@ -27,6 +27,7 @@ const List = styled.ul`
   display: block;
   padding-bottom: 80px;
   width: 100%;
+  overflow: scroll;
 `
 
 class VideoList extends Component<Props, void> {

--- a/src/scripts/components/VideoList.js
+++ b/src/scripts/components/VideoList.js
@@ -7,6 +7,7 @@ import type { Map } from 'immutable'
 import VideoListItem from 'containers/VideoListItemContainer'
 import Card from 'components/structures/Card'
 import Button from 'components/foundations/Button'
+import { VIDEO_MANAGER_MAX_HEIGHT } from 'constants/UIConstants'
 
 type Props = {
   videos: Map<string, VideoRecord>, // maps video ids to upload records
@@ -14,6 +15,10 @@ type Props = {
   setSelectedVideo: Object => void,
   videoFormRef: Object
 }
+
+const Wrapper = styled(Card)`
+  max-height: ${VIDEO_MANAGER_MAX_HEIGHT};
+`
 
 const Title = styled.h3`
   color: ${props => props.theme.colors.VideoList.title};
@@ -51,7 +56,7 @@ class VideoList extends Component<Props, void> {
       ''
     )
     return (
-      <Card {...this.props} nopadding nobackground footer={footer}>
+      <Wrapper {...this.props} nopadding nobackground footer={footer}>
         <Title>Video List</Title>
         <List>
           {this.props.videos
@@ -65,7 +70,7 @@ class VideoList extends Component<Props, void> {
               />
             ))}
         </List>
-      </Card>
+      </Wrapper>
     )
   }
 }

--- a/src/scripts/components/VideoManager.js
+++ b/src/scripts/components/VideoManager.js
@@ -9,6 +9,8 @@ import RedeemVoucher from 'containers/RedeemVoucherContainer'
 import VideoList from 'containers/VideoListContainer'
 import VideoForm from 'containers/VideoFormContainer'
 import UploadFile from 'containers/FileUploaderContainer'
+import { VIDEO_MANAGER_MAX_HEIGHT } from 'constants/UIConstants'
+
 import type { Match } from 'react-router-dom'
 
 type Props = {
@@ -24,7 +26,7 @@ const Wrapper = CardContainer.extend`
   margin: 0 auto;
   max-width: 1500px;
   width: 100%;
-  max-height: 600px;
+  max-height: ${VIDEO_MANAGER_MAX_HEIGHT};
 
   @media (max-width: 1280px) {
     justify-content: ${props => (props.padding ? 'space-between' : 'center')};

--- a/src/scripts/components/VideoManager.js
+++ b/src/scripts/components/VideoManager.js
@@ -24,6 +24,7 @@ const Wrapper = CardContainer.extend`
   margin: 0 auto;
   max-width: 1500px;
   width: 100%;
+  max-height: 600px;
 
   @media (max-width: 1280px) {
     justify-content: ${props => (props.padding ? 'space-between' : 'center')};

--- a/src/scripts/constants/UIConstants.js
+++ b/src/scripts/constants/UIConstants.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+export const VIDEO_MANAGER_MAX_HEIGHT: string = '600px'


### PR DESCRIPTION
**Problem** 
When you have uploaded a lot of videos, your video list can grow super tall making the other activities on the upload page too tall to be usable.

![heightfail](https://user-images.githubusercontent.com/7697924/37551302-c8675544-2973-11e8-8d1f-a131f1adca63.gif)


***


**Fix**
Set a max height for the video manager and add scrolling to the video list


![heightwin](https://user-images.githubusercontent.com/7697924/37556932-742b2bda-29d3-11e8-8b06-48525f849b20.gif)


