### PR TITLE
360 - fully hide controls and fix player bug

### DIFF
--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -426,6 +426,7 @@ class Play extends Component<Props, State> {
 
     // Space key
     if (e.keyCode === 32) {
+      e.preventDefault()
       this.togglePlayPause()
     }
   }

--- a/src/scripts/components/PlayerControls.js
+++ b/src/scripts/components/PlayerControls.js
@@ -56,7 +56,7 @@ const Controls = styled.div`
     switch (transitionState) {
       case TRANSITION_STATE.ENTERING:
       case TRANSITION_STATE.EXITED:
-        return `calc(${CONTROLS_HEIGHT} - ${PROGRESS_INDICATOR_DIMENSION}px)`
+        return `calc(${CONTROLS_HEIGHT} + ${PROGRESS_INDICATOR_DIMENSION}px)`
       case TRANSITION_STATE.EXITING:
       case TRANSITION_STATE.ENTERED:
       default:


### PR DESCRIPTION
**Issue**
#360 

**Problem**
The seek bar never fully hid when playing a video

**Work Done**
- fully hide controls
- when playing/pausing via space bar, prevent browser from also scrolling on this key press (it led to a very bad UX)

**Demo**

![hidecontrolswin](https://user-images.githubusercontent.com/7697924/37551541-ebd63d66-2977-11e8-9594-2bf847a2d4f7.gif)


cc @felipegaucho 