### PR TITLE
Disable Modal

### DIFF
--- a/src/scripts/actions/ModalActions.js
+++ b/src/scripts/actions/ModalActions.js
@@ -2,7 +2,12 @@
 
 import { createAction } from 'redux-actions'
 
-import { OPEN_MODAL, CLOSE_MODAL } from 'constants/ActionConstants'
+import {
+  OPEN_MODAL,
+  CLOSE_MODAL,
+  DISABLE_MODAL
+} from 'constants/ActionConstants'
 
 export const openModal = createAction(OPEN_MODAL)
 export const closeModal = createAction(CLOSE_MODAL)
+export const disableModal = createAction(DISABLE_MODAL)

--- a/src/scripts/components/structures/header/MainHeader.js
+++ b/src/scripts/components/structures/header/MainHeader.js
@@ -18,7 +18,7 @@ const Header = styled.header`
   position: fixed;
   width: 100%;
   height: ${props => props.theme.sizes.mainHeader.height};
-  z-index: 10000;
+  z-index: 990;
   transition: box-shadow 0.3s;
   box-shadow: ${({ displayShadow }) =>
     displayShadow ? '0 3px 5px rgba(0,0,0,0.16)' : ''};

--- a/src/scripts/components/widgets/modals/Modal.js
+++ b/src/scripts/components/widgets/modals/Modal.js
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 999;
+  z-index: 1000;
 `
 
 const Background = styled.span`

--- a/src/scripts/components/widgets/modals/ModalStake.js
+++ b/src/scripts/components/widgets/modals/ModalStake.js
@@ -14,11 +14,13 @@ type Props = {
   author: string,
   user: UserRecord,
   modalProps: Object,
+  modalIsDisabled: boolean,
   closeModal: () => void,
   saveVideoStaked: Object => Object,
   selectedVideo: Object => Object,
   notification: (Object, string) => void,
-  loadBalances: () => void
+  loadBalances: () => void,
+  disableModal: boolean => void
 }
 
 const Title = styled.h2`
@@ -58,6 +60,8 @@ class ModalStake extends Component<Props, Object> {
   }
 
   onSubmit (event: Object) {
+    this.props.disableModal(true)
+
     const { loadBalances } = this.props
     event.preventDefault()
     this.props.notification({ title: 'Processing...' }, 'warning')
@@ -69,6 +73,7 @@ class ModalStake extends Component<Props, Object> {
     paratii.eth.tcr
       .checkEligiblityAndApply(videoIdStaked, stakeAmountWei)
       .then(resp => {
+        this.props.disableModal(false)
         if (resp && resp === true) {
           this.setState({
             errorMessage: false
@@ -101,6 +106,7 @@ class ModalStake extends Component<Props, Object> {
         }
       })
       .catch(e => {
+        this.props.disableModal(false)
         if (e) {
           const msg = String(e)
           this.setState({
@@ -167,7 +173,11 @@ class ModalStake extends Component<Props, Object> {
             </MainText>
           ) : (
             <Footer>
-              <Button purple onClick={this.onSubmit}>
+              <Button
+                purple
+                onClick={this.onSubmit}
+                disabled={this.props.modalIsDisabled}
+              >
                 Continue
               </Button>
             </Footer>

--- a/src/scripts/components/widgets/modals/ModalStake.js
+++ b/src/scripts/components/widgets/modals/ModalStake.js
@@ -86,7 +86,7 @@ class ModalStake extends Component<Props, Object> {
           this.props.notification(
             {
               title: 'Stake well-done',
-              message: `You have staked ${stakeAmount}PTI.`
+              message: `You have staked ${stakeAmount} PTI.`
             },
             'success'
           )

--- a/src/scripts/constants/ActionConstants.js
+++ b/src/scripts/constants/ActionConstants.js
@@ -72,3 +72,4 @@ export const TRANSCODING_FAILURE = createActionConstant('TRANSCODING_FAILURE')
 
 export const OPEN_MODAL = createActionConstant('OPEN_MODAL')
 export const CLOSE_MODAL = createActionConstant('CLOSE_MODAL')
+export const DISABLE_MODAL = createActionConstant('DISABLE_MODAL')

--- a/src/scripts/containers/ModalStakeContainer.js
+++ b/src/scripts/containers/ModalStakeContainer.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { show } from 'react-notification-system-redux'
 
-import { closeModal } from 'actions/ModalActions'
+import { closeModal, disableModal } from 'actions/ModalActions'
 import { getSelectedUploaderVideo } from 'selectors/UploaderSelectors'
 import { saveVideoStaked, uploadAndTranscode } from 'actions/UploaderActions'
 import { getUser } from 'selectors/index'
@@ -15,13 +15,15 @@ import type { RootState } from 'types/ApplicationTypes'
 
 const mapStateToProps = (state: RootState) => ({
   selectedVideo: getSelectedUploaderVideo(state),
-  user: getUser(state)
+  user: getUser(state),
+  modalIsDisabled: state.modal.modalIsDisabled
 })
 
 const mapDispatchToProps = dispatch => ({
   saveVideoStaked: bindActionCreators(saveVideoStaked, dispatch),
   uploadAndTranscode: bindActionCreators(uploadAndTranscode, dispatch),
   closeModal: bindActionCreators(closeModal, dispatch),
+  disableModal: bindActionCreators(disableModal, dispatch),
   notification: bindActionCreators(show, dispatch),
   loadBalances: bindActionCreators(loadBalances, dispatch)
 })

--- a/src/scripts/records/ModalRecord.js
+++ b/src/scripts/records/ModalRecord.js
@@ -4,10 +4,12 @@ import { Record as ImmutableRecord } from 'immutable'
 
 class ModalRecord extends ImmutableRecord({
   modalContent: '',
-  showModal: false
+  showModal: false,
+  modalIsDisabled: false
 }) {
   modalContent: string
   showModal: boolean
+  modalIsDisabled: boolean
 }
 
 export default ModalRecord

--- a/src/scripts/reducers/ModalReducer.js
+++ b/src/scripts/reducers/ModalReducer.js
@@ -1,7 +1,11 @@
 import { handleActions } from 'redux-actions'
 
 import ModalRecord from 'records/ModalRecord'
-import { OPEN_MODAL, CLOSE_MODAL } from 'constants/ActionConstants'
+import {
+  OPEN_MODAL,
+  CLOSE_MODAL,
+  DISABLE_MODAL
+} from 'constants/ActionConstants'
 
 import type { Action } from 'types/ApplicationTypes'
 
@@ -14,7 +18,12 @@ const reducer = {
   },
   [CLOSE_MODAL]: (state: ModalRecord, action: Action<boolean>) => {
     return state.merge({
-      showModal: false
+      showModal: !!state.modalIsDisabled
+    })
+  },
+  [DISABLE_MODAL]: (state: ModalRecord, action: Action<boolean>) => {
+    return state.merge({
+      modalIsDisabled: action.payload
     })
   }
 }

--- a/src/scripts/types/ApplicationTypes.js
+++ b/src/scripts/types/ApplicationTypes.js
@@ -7,6 +7,7 @@ import UserRecord from 'records/UserRecords'
 import PlayerRecord from 'records/PlayerRecords'
 import UploaderRecord from 'records/UploaderRecords'
 import NotificationRecord from 'records/NotificationRecord'
+import ModalRecord from 'records/ModalRecord'
 import {
   REQUEST_STATUS,
   TRANSITION_STATE
@@ -39,7 +40,8 @@ export type RootState = {
   user: UserRecord,
   videos: VideoRecordMap,
   player: PlayerRecord,
-  notifications: NotificationsArray
+  notifications: NotificationsArray,
+  modal: ModalRecord
 }
 
 type _ThunkAction<R> = (dispatch: Dispatch, getState?: () => RootState) => R


### PR DESCRIPTION
- import `ModalRecord` to `RootState`
https://github.com/Paratii-Video/paratii-portal/blob/5ad4262f7688e9ba100982de86ac322375db40c1/src/scripts/types/ApplicationTypes.js#L44


- > When the staking is "processing", the "continue" button should be disabled #388 

The [disableModal action](https://github.com/Paratii-Video/paratii-portal/blob/5ad4262f7688e9ba100982de86ac322375db40c1/src/scripts/actions/ModalActions.js#L13) changes the value of the [modalIsDisabled record](https://github.com/Paratii-Video/paratii-portal/blob/5ad4262f7688e9ba100982de86ac322375db40c1/src/scripts/records/ModalRecord.js#L12) . The ["continue" button ](https://github.com/Paratii-Video/paratii-portal/blob/5ad4262f7688e9ba100982de86ac322375db40c1/src/scripts/components/widgets/modals/ModalStake.js#L179) and [closeModal](https://github.com/Paratii-Video/paratii-portal/blob/5ad4262f7688e9ba100982de86ac322375db40c1/src/scripts/reducers/ModalReducer.js#L21) are disable by this record.

https://github.com/Paratii-Video/paratii-portal/blob/5ad4262f7688e9ba100982de86ac322375db40c1/src/scripts/reducers/ModalReducer.js#L24-L28


- Changes the z-index of the Modal and MainHeader