### PR TITLE
400 - always destroy player before creating a new one

### DIFF
--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -552,9 +552,7 @@ class Play extends Component<Props, State> {
 
   createPlayer = (video: VideoRecord): void => {
     const { updateVolume } = this.props
-    if (this.player && this.player.destroy) {
-      this.player.destroy()
-    }
+
     if (!video.ipfsHash) {
       throw new Error("Can't create player without ipfsHash")
     }
@@ -563,6 +561,10 @@ class Play extends Component<Props, State> {
       poster = video.thumbnails.get(0)
     }
     import('paratii-mediaplayer').then(CreatePlayer => {
+      if (this.player && this.player.destroy) {
+        this.player.destroy()
+      }
+
       this.player = CreatePlayer({
         selector: `#${PLAYER_ID}`,
         source: `https://gateway.paratii.video/ipfs/${


### PR DESCRIPTION
**Issue**
#400 

**Problem**
The play component could accidentally render two video elements simultaneously, which led to a terrible player experience. The controls would jump around and you would hear two videos while only seeing one!

**Work Done**
Ensure all players are destroyed the moment before creating a new one.