### PR TITLE
mediaplayer-41 - only render fullscreen button if fullscreen is enabled

### DIFF
--- a/src/scripts/components/PlayerControls.js
+++ b/src/scripts/components/PlayerControls.js
@@ -27,6 +27,7 @@ import {
   CONTROLS_HEIGHT_TABLET
 } from 'constants/UIConstants'
 import { PLAYER_PLUGIN } from 'constants/PlayerConstants'
+import { getFullscreenEnabled } from 'utils/AppUtils'
 
 import playIcon from 'assets/svg/icon-player-play.svg'
 import pauseIcon from 'assets/svg/icon-player-pause.svg'
@@ -338,14 +339,16 @@ class PlayerControls extends Component<Props, State> {
                   }}
                 />
               </ControlButtonWrapper>
-              <ControlButtonWrapper>
-                <IconButton
-                  icon={isFullscreen ? normalscreenIcon : fullscreenIcon}
-                  onClick={() => {
-                    toggleFullscreen(!isFullscreen)
-                  }}
-                />
-              </ControlButtonWrapper>
+              {getFullscreenEnabled() && (
+                <ControlButtonWrapper>
+                  <IconButton
+                    icon={isFullscreen ? normalscreenIcon : fullscreenIcon}
+                    onClick={() => {
+                      toggleFullscreen(!isFullscreen)
+                    }}
+                  />
+                </ControlButtonWrapper>
+              )}
             </RightControls>
           </ControlButtons>
         </Controls>

--- a/src/scripts/utils/AppUtils.js
+++ b/src/scripts/utils/AppUtils.js
@@ -120,6 +120,13 @@ export const requestFullscreen = (element: HTMLElement): void => {
   }
 }
 
+export const getFullscreenEnabled = () =>
+  document.fullscreenEnabled ||
+  document.webkitFullscreenEnabled ||
+  document.mozFullScreenEnabled ||
+  // $FlowFixMe
+  document.msFullscreenEnabled
+
 export const copyTextToClipboard = (element: HTMLElement): void => {
   const { body } = document
 


### PR DESCRIPTION
**Issue**
[paratii-mediaplayer#41](https://github.com/Paratii-Video/paratii-mediaplayer/issues/41)

**Problem**
We were rendering the fullscreen button in the player on twitter (and any other `iframe`), but we should hide this button when fullscreen mode is not enabled (which it is not on twitter).

**Screenshot**

![image](https://user-images.githubusercontent.com/7697924/38160027-ea0f9cf4-3483-11e8-97a1-c89d179194c5.png)

cc @felipegaucho 