### PR TITLE
Update readme for yarn troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ If you are on a Mac, you may need to set the path to parity:
 ☝️ add the `--pure-lockfile` argument to `yarn` to ensure you install all dependencies exactly as specified in the current `yarn.lock` file.
 
 
-
-
 ## Testing
 
 To run unit tests:


### PR DESCRIPTION
@jellegerbrandy this bit me today. There is an [open issue](https://github.com/yarnpkg/yarn/issues/4722) w/ `yarn` where it does not install the correct version of git commit hash dependencies sometimes.

We have a workaround (which is documented in this PR), but I do not believe this would happen if we were to switch to version numbers. The `yarn` team should definitely fix this, though.