### PR TITLE
382 - enable autoplay param

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "paratii-js": "github:Paratii-Video/paratii-js#189889cc8dd95fcf4209835e64b6eecab7f8344c",
     "paratii-mediaplayer": "^3.0.3",
     "player.js": "^0.1.0",
-    "query-string": "^5.0.1",
+    "query-string": "^6.0.0",
     "react": "^16.2.0",
     "react-blockies": "^1.2.2",
     "react-dom": "^16.2.0",

--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -7,6 +7,7 @@ import debounce from 'lodash.debounce'
 import Transition from 'react-transition-group/Transition'
 import TimeFormat from 'hh-mm-ss'
 import playerjs from 'player.js'
+import queryString from 'query-string'
 
 import { PlaybackLevel } from 'records/PlayerRecords'
 import VideoRecord from 'records/VideoRecords'
@@ -18,6 +19,7 @@ import Card from 'components/structures/Card'
 import ShareOverlay from 'containers/widgets/ShareOverlayContainer'
 import VideoNotFound from './pages/VideoNotFound'
 import { requestFullscreen, requestCancelFullscreen } from 'utils/AppUtils'
+import { PLAYER_PARAMS } from 'constants/PlayerConstants'
 
 import type { ClapprPlayer, PlayerPlugin } from 'types/ApplicationTypes'
 import type { Match } from 'react-router-dom'
@@ -526,7 +528,7 @@ class Play extends Component<Props, State> {
         }/${poster}`,
         mimeType: 'application/x-mpegURL',
         ipfsHash: video.ipfsHash,
-        autoPlay: true
+        autoPlay: this.getAutoPlaySetting()
       })
 
       this.bindClapprEvents()
@@ -575,6 +577,31 @@ class Play extends Component<Props, State> {
 
   shouldShowVideoOverlay (): boolean {
     return this.state.mouseInOverlay
+  }
+
+  getAutoPlaySetting (): boolean {
+    const parsedQueryString = queryString.parse(location.search)
+
+    const hasAutoPlayParam: boolean = Object.prototype.hasOwnProperty.call(
+      parsedQueryString,
+      PLAYER_PARAMS.AUTOPLAY
+    )
+
+    if (!hasAutoPlayParam) {
+      return true
+    }
+
+    const paramValue: string = parsedQueryString[PLAYER_PARAMS.AUTOPLAY]
+
+    const parsedNumberValue: number = parseInt(paramValue, 10)
+
+    if (!isNaN(parsedNumberValue)) {
+      return !!parsedNumberValue
+    }
+
+    const valueIsFalse: boolean = paramValue.toLowerCase() === 'false'
+
+    return !valueIsFalse
   }
 
   getPortalUrl () {

--- a/src/scripts/constants/PlayerConstants.js
+++ b/src/scripts/constants/PlayerConstants.js
@@ -6,3 +6,7 @@ export const PLAYER_PLUGIN: Object = {
   PLAYBACK_LEVELS: makePluginConstant('PLAYBACK_LEVEL'),
   WALLET: makePluginConstant('WALLET')
 }
+
+export const PLAYER_PARAMS: Object = {
+  AUTOPLAY: 'autoplay'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13083,6 +13083,13 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.0.0.tgz#8b8f39447b73e8290d6f5e3581779218e9171142"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0, querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -15171,6 +15178,10 @@ streamspeed@^1.1.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-template@~0.2.1:
   version "0.2.1"


### PR DESCRIPTION
**Issue**
#382 (and related to #449, which is partially addressed by this PR).

**Problem**
We had no way of turning off autoplay for the embed player

**Work Done**
- allow disabling of autoplay via `autoplay` query param (for embed only)
- show controls until video plays (cc @pedrocasa, thoughts on this?)

**Notes**
- the default is still to autoplay if this query param is left out
- users can disable autoplay by passing in a `0` or `false`

**Demo**

![autoplaywin](https://user-images.githubusercontent.com/7697924/38532213-c074f3ec-3c41-11e8-9884-c113b142442e.gif)
