### PR TITLE
475 - remove hard-coded urls

### DIFF
--- a/src/scripts/components/App.js
+++ b/src/scripts/components/App.js
@@ -93,6 +93,7 @@ class App extends Component<Props, State> {
               <Route path={`${match.url}debug`} component={DebugContainer} />
               <Route path={`${match.url}wallet`} component={WalletContainer} />
               <Route path={`${match.url}play/:id`} component={PlayContainer} />
+              <Route path={`${match.url}embed/:id`} component={PlayContainer} />
               <Route component={NotFound} />
             </Switch>
           </Main>

--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -18,7 +18,11 @@ import Text from 'components/foundations/Text'
 import Card from 'components/structures/Card'
 import ShareOverlay from 'containers/widgets/ShareOverlayContainer'
 import VideoNotFound from './pages/VideoNotFound'
-import { requestFullscreen, requestCancelFullscreen } from 'utils/AppUtils'
+import {
+  requestFullscreen,
+  requestCancelFullscreen,
+  getAppRootUrl
+} from 'utils/AppUtils'
 import { PLAYER_PARAMS } from 'constants/PlayerConstants'
 
 import type { ClapprPlayer, PlayerPlugin } from 'types/ApplicationTypes'
@@ -629,49 +633,54 @@ class Play extends Component<Props, State> {
     return !valueIsFalse
   }
 
-  getPortalUrl () {
-    // FIXME: do not hardcode this here
-    return 'https://portal.paratii.video'
-  }
   getFacebookHref () {
     const { video } = this.props
+    const appRootUrl = getAppRootUrl(process.env.NODE_ENV)
     if (video) {
       var baseurl = 'https://www.facebook.com/sharer/sharer.php?u='
-      return baseurl + this.getPortalUrl() + '/play/' + video.id
+      return baseurl + appRootUrl + '/play/' + video.id
     }
   }
   getTwitterHref () {
     const { video } = this.props
+    const appRootUrl = getAppRootUrl(process.env.NODE_ENV)
+
     if (video) {
       const baseurl = 'https://twitter.com/intent/tweet'
-      const url = '?url=' + this.getPortalUrl() + '/play/' + video.id
+      const url = '?url=' + appRootUrl + '/play/' + video.id
       const text = '&text=🎬 Worth a watch: ' + video.title
       return baseurl + url + text
     }
   }
   getWhatsAppMobileHref () {
     const { video } = this.props
+    const appRootUrl = getAppRootUrl(process.env.NODE_ENV)
+
     if (video) {
       const baseurl = 'whatsapp://send?text='
-      const url = this.getPortalUrl() + '/play/' + video.id
+      const url = appRootUrl + '/play/' + video.id
       const text = '🎬 Worth a watch: ' + video.title + ' '
       return baseurl + text + url
     }
   }
   getWhatsAppDesktopHref () {
     const { video } = this.props
+    const appRootUrl = getAppRootUrl(process.env.NODE_ENV)
+
     if (video) {
       const baseurl = 'https://web.whatsapp.com/send?text='
-      const url = this.getPortalUrl() + '/play/' + video.id
+      const url = appRootUrl + '/play/' + video.id
       const text = '🎬 Worth a watch: ' + video.title + ' '
       return baseurl + text + url
     }
   }
   getTelegramHref () {
     const { video } = this.props
+    const appRootUrl = getAppRootUrl(process.env.NODE_ENV)
+
     if (video) {
       const baseurl = 'https://t.me/share/url'
-      const url = '?url=' + this.getPortalUrl() + '/play/' + video.id
+      const url = '?url=' + appRootUrl + '/play/' + video.id
       const text = '&text=🎬 Worth a watch: ' + video.title
       return baseurl + url + text
     }
@@ -749,10 +758,12 @@ class Play extends Component<Props, State> {
                 <ShareOverlay
                   show={this.state.showShareModal}
                   onToggle={this.toggleShareModal}
-                  portalUrl={this.getPortalUrl()}
+                  portalUrl={getAppRootUrl(process.env.NODE_ENV)}
                   videoId={video && video.id}
                   videoLabelUrl={
-                    this.getPortalUrl() + '/play/' + ((video && video.id) || '')
+                    getAppRootUrl(process.env.NODE_ENV) +
+                    '/play/' +
+                    ((video && video.id) || '')
                   }
                   shareOptions={shareOptions}
                 />

--- a/src/scripts/components/VideoFormInfoBox.js
+++ b/src/scripts/components/VideoFormInfoBox.js
@@ -10,6 +10,7 @@ import TextField from './widgets/forms/TextField'
 import VideoProgress from 'components/widgets/VideoForm/VideoProgress'
 import Hidden from 'components/foundations/Hidden'
 import VideoProgressTitle from 'components/widgets/VideoForm/VideoProgressTitle'
+import { getAppRootUrl } from 'utils/AppUtils'
 
 const VideoFormInfoBox = styled.div`
   flex: 1 1 584px;
@@ -145,7 +146,9 @@ class InfoBox extends Component<Props, Object> {
     // const fileSize = prettyBytes((video && video.get('filesize')) || 0)
     const ipfsHash = (video && video.get('ipfsHash')) || ''
     const urlToPlay = `/play/${video.id}`
-    const urlForSharing = `https://portal.paratii.video/play/${video.id}`
+    const urlForSharing = `${getAppRootUrl(process.env.NODE_ENV)}/play/${
+      video.id
+    }`
 
     const thumbImages: ImmutableList<string> =
       (video && video.getIn(['thumbnails'])) || ImmutableList()

--- a/src/scripts/utils/AppUtils.js
+++ b/src/scripts/utils/AppUtils.js
@@ -15,6 +15,20 @@ export const getRoot = (): Element => {
   return root
 }
 
+export const getAppRootUrl = (env: ?string = 'development'): string => {
+  switch (env) {
+    case 'production':
+      return 'https://portal.paratii.video'
+    case 'test':
+      return 'https://staging.paratii.video'
+    case 'staging':
+      return 'https://staging.paratii.video'
+    case 'development':
+    default:
+      return 'http://localhost:8080'
+  }
+}
+
 export const getParatiiConfig = (env: ?string = 'development'): Object => {
   let config = {}
 

--- a/src/server/routes/embed.js
+++ b/src/server/routes/embed.js
@@ -2,7 +2,7 @@
 
 import type { $Request, $Response } from 'express'
 import { Paratii } from 'paratii-js/dist/paratii'
-import { getParatiiConfig } from 'utils/AppUtils'
+import { getParatiiConfig, getAppRootUrl } from 'utils/AppUtils'
 
 const paratiiConfig = getParatiiConfig(process.env.NODE_ENV)
 
@@ -44,9 +44,10 @@ module.exports = async (req: $Request, res: $Response) => {
   const thumbName = video.transcodingStatus.data.result.screenshots[0]
   const thumbnailUrl =
     'https://gateway.paratii.video/ipfs/' + ipfsHash + '/' + thumbName
+  const appRootUrl = getAppRootUrl(process.env.NODE_ENV)
 
-  const url = `https://portal.paratii.video/play/${id}`
-  const embedUrl = `https://portal.paratii.video/embed/${id}`
+  const url = `${appRootUrl}/play/${id}`
+  const embedUrl = `${appRootUrl}/embed/${id}`
   const height = `1080`
   const width = `1920`
   // this needs to be the has of a video - just as the thumbnail, we need to save these data from paratii-db

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,4 +1,4 @@
-const { getParatiiConfig } = require('utils/AppUtils')
+const { getParatiiConfig, getAppRootUrl } = require('utils/AppUtils')
 const { Paratii } = require('paratii-js')
 const paratiiConfig = getParatiiConfig(process.env.NODE_ENV)
 const paratii = new Paratii(paratiiConfig)
@@ -19,6 +19,7 @@ exports.player = async function player (req, res, next) {
   const { id } = req.params
   const path = req.route.path
   const video = await paratii.vids.get(id)
+  const appRootUrl = getAppRootUrl(process.env.NODE_ENV)
 
   res.render('index', {
     player: true,
@@ -53,16 +54,16 @@ exports.player = async function player (req, res, next) {
         )
       },
       videoUrl: function () {
-        return 'https://portal.paratii.video/play/' + video._id
+        return `${appRootUrl}/${video.id}`
       },
       ipfsSource: function () {
         return `https://gateway.paratii.video/ipfs/` + video.ipfsHashOrig
       },
       embedUrl: function () {
-        return 'https://portal.paratii.video/embed/' + video._id
+        return `${appRootUrl}/embed/${video}`
       },
       oembedUrl: function () {
-        return 'https://portal.paratii.video/oembed?url='
+        return `${appRootUrl}/oembed?url=`
       }
     }
   })

--- a/src/server/routes/oembed.js
+++ b/src/server/routes/oembed.js
@@ -1,6 +1,6 @@
 import type { $Request, $Response } from 'express'
 import { Paratii } from 'paratii-js/dist/paratii'
-import { getParatiiConfig } from 'utils/AppUtils'
+import { getParatiiConfig, getAppRootUrl } from 'utils/AppUtils'
 
 const paratiiConfig = getParatiiConfig(process.env.NODE_ENV)
 const paratii = new Paratii(paratiiConfig)
@@ -12,7 +12,7 @@ module.exports = async (req: $Request, res: $Response) => {
     res.end(JSON.stringify(oembedresponse))
   }
 
-  const baseUrl = 'https://portal.paratii.video'
+  const baseUrl = getAppRootUrl(process.env.NODE_ENV)
   const parsedExternalUrl = parseUrl(req.query.url)
   const parsedInternalUrl = parseUrl(baseUrl)
   console.log(parsedInternalUrl)


### PR DESCRIPTION
**Issue**
#475 

**Problem**
We have hard-coded urls in our app that make testing embeds (and other things) on staging difficult or impossible.

**Work Done**
- remove all instances of hard-coded `portal.paratii.video` urls from our app
- add a util that gets the right url based on the environment
