### PR TITLE
449 - don't show start screen if we are playing for any reason

### DIFF
--- a/src/scripts/components/Play.js
+++ b/src/scripts/components/Play.js
@@ -58,8 +58,8 @@ type Props = {
 }
 
 type State = {
+  hasNeverPlayed: boolean,
   isEmbed: boolean,
-  isStartScreen: boolean,
   mouseInOverlay: boolean,
   shouldShowVideoOverlay: boolean,
   showShareModal: boolean,
@@ -179,12 +179,12 @@ class Play extends Component<Props, State> {
     super(props)
 
     this.state = {
+      hasNeverPlayed: true,
       mouseInOverlay: false,
       shouldShowVideoOverlay: false,
       videoNotFound: false,
       playerCreated: '',
       isEmbed: this.props.isEmbed || false,
-      isStartScreen: this.props.isEmbed || false,
       showShareModal: false,
       videoHasNeverPlayed: true
     }
@@ -222,6 +222,12 @@ class Play extends Component<Props, State> {
     if (player) {
       player.on(Events.PLAYER_PLAY, (): void => {
         togglePlayPause(true)
+
+        this.setState((prevState: State) => {
+          if (prevState.hasNeverPlayed) {
+            return { hasNeverPlayed: false }
+          }
+        })
       })
       player.on(Events.PLAYER_PAUSE, (): void => {
         togglePlayPause(false)
@@ -589,12 +595,6 @@ class Play extends Component<Props, State> {
       } else {
         player.play()
       }
-
-      this.setState(prevState => {
-        if (prevState.isStartScreen) {
-          return { isStartScreen: false }
-        }
-      })
     }
   }
 
@@ -698,11 +698,13 @@ class Play extends Component<Props, State> {
   }
 
   shouldShowStartScreen () {
-    return this.props.isEmbed && this.props.isPlaying
+    const { isAttemptingPlay, isEmbed } = this.props
+
+    return !isAttemptingPlay && isEmbed && this.state.hasNeverPlayed
   }
 
   render () {
-    const { isEmbed, video } = this.props
+    const { isAttemptingPlay, isEmbed, video } = this.props
 
     const shareOptions = [
       {
@@ -745,7 +747,11 @@ class Play extends Component<Props, State> {
                       onClick={this.onOverlayClick}
                       video={video}
                       isEmbed={isEmbed}
-                      isStartScreen={this.state.isStartScreen}
+                      showStartScreen={
+                        isEmbed &&
+                        this.state.hasNeverPlayed &&
+                        !isAttemptingPlay
+                      }
                       toggleShareModal={this.toggleShareModal}
                       showShareModal={this.state.showShareModal}
                       onScrub={this.scrubVideo}

--- a/src/scripts/components/VideoOverlay.js
+++ b/src/scripts/components/VideoOverlay.js
@@ -24,7 +24,7 @@ import type { TransitionState, PlayerPlugin } from 'types/ApplicationTypes'
 type Props = {
   video: ?VideoRecord,
   isEmbed?: boolean,
-  isStartScreen?: boolean,
+  showStartScreen?: boolean,
   onClick: (e: Object) => void,
   transitionState: ?TransitionState,
   showShareModal?: boolean,
@@ -69,7 +69,7 @@ const Wrapper = styled.div`
 
 const PlayerControlsWrapper = styled.div`
   bottom: 0;
-  pointer-events: ${props => (props.isStartScreen ? 'none' : null)};
+  pointer-events: ${props => (props.showStartScreen ? 'none' : null)};
   position: absolute;
   width: 100%;
   z-index: ${Z_INDEX_CONTROLS};
@@ -159,7 +159,7 @@ const CentralizedContent = styled.div`
 
 const StartScreenIcon = styled.span`
   height: 20%;
-  opacity: ${props => (props.isStartScreen ? 1 : 0)};
+  opacity: ${props => (props.showStartScreen ? 1 : 0)};
   transition: transform 0.3s ${props => props.theme.animation.ease.smooth};
   ${Overlay}:hover & {
     transform: scale(0.9);
@@ -209,7 +209,7 @@ class VideoOverlay extends Component<Props> {
     const {
       activePlugin,
       isEmbed,
-      isStartScreen,
+      showStartScreen,
       onClick,
       onScrub,
       onVolumeChange,
@@ -276,7 +276,7 @@ class VideoOverlay extends Component<Props> {
             showShareModal={showShareModal}
           >
             {isEmbed && (
-              <StartScreenIcon isStartScreen={isStartScreen}>
+              <StartScreenIcon showStartScreen={showStartScreen}>
                 <StartScreenSVG>
                   <use xlinkHref="#icon-player-play" />
                 </StartScreenSVG>
@@ -284,7 +284,7 @@ class VideoOverlay extends Component<Props> {
             )}
           </CentralizedContent>
         </Overlay>
-        <PlayerControlsWrapper isStartScreen={isStartScreen}>
+        <PlayerControlsWrapper showStartScreen={showStartScreen}>
           <PlayerControlsContainer
             onScrub={onScrub}
             onVolumeChange={onVolumeChange}
@@ -294,7 +294,7 @@ class VideoOverlay extends Component<Props> {
             toggleFullscreen={toggleFullscreen}
             transitionState={transitionState}
             showShareModal={showShareModal}
-            isStartScreen={isStartScreen}
+            showStartScreen={showStartScreen}
           />
         </PlayerControlsWrapper>
       </Wrapper>


### PR DESCRIPTION
**Issue**
#449 

**Problem**
When a video played because of autoplay, the start screen would not go away

![autoplayfail](https://user-images.githubusercontent.com/7697924/39334813-3de0f0e4-497e-11e8-9d66-e14a12fb25a1.gif)



**Work Done**
Hide the start screen if the video plays for any reason (including autoplay)

![autoplaywin](https://user-images.githubusercontent.com/7697924/39334842-65ff3f4a-497e-11e8-8e38-004f4c4e01ff.gif)
