### PR TITLE
218 - Fix paginated searching

### DIFF
--- a/src/scripts/actions/SearchActions.js
+++ b/src/scripts/actions/SearchActions.js
@@ -47,8 +47,8 @@ export const searchForVideos = ({ keyword }: Object = {}) => async (
       const searchOffset: number = 0
       const searchResults: SearchResults = await paratii.vids.search({
         keyword,
-        limit: `${SEARCH_BATCH_SIZE}`,
-        offset: '0'
+        limit: SEARCH_BATCH_SIZE,
+        offset: 0
       })
       const results: Array<VideoInfo> = searchResults.results
       dispatch(
@@ -76,8 +76,8 @@ export const searchForMoreVideos = () => async (
     try {
       const searchResults: SearchResults = await paratii.vids.search({
         keyword,
-        limit: `${SEARCH_BATCH_SIZE}`,
-        offset: `${nextSearchOffset}`
+        limit: SEARCH_BATCH_SIZE,
+        offset: nextSearchOffset
       })
 
       const results: Array<VideoInfo> = searchResults.results || []

--- a/src/scripts/reducers/SearchReducer.js
+++ b/src/scripts/reducers/SearchReducer.js
@@ -32,10 +32,15 @@ const reducer = {
     }),
   [SEARCH_RESULTS_LOADED]: (
     state: Search,
-    action: Action<{ hasNext: boolean, results: Array<VideoInfo> }>
+    action: Action<{
+      hasNext: boolean,
+      nextSearchOffset: number,
+      results: Array<VideoInfo>
+    }>
   ): Search =>
     state.merge({
       hasNext: action.payload.hasNext,
+      nextSearchOffset: action.payload.nextSearchOffset,
       results: ImmutableList(
         action.payload.results.map(
           (video: VideoInfo): Video => new Video(video)


### PR DESCRIPTION
⚠️ DEPENDENT ON https://github.com/Paratii-Video/paratii-js/pull/226 ⚠️ 

**Issue**
#218 

**Work Done***
- update types of params passed to `.search()` call
- fix logic for paginating search results in the search reducer