### PR TITLE
130 search UI fixes

### DIFF
--- a/src/scripts/components/pages/SearchResults.js
+++ b/src/scripts/components/pages/SearchResults.js
@@ -46,7 +46,7 @@ const ZeroState = styled.div`
 const Results = styled.div`
   width: 100%;
   flex: 1 0 auto;
-  overflow-y: auto;
+  padding-bottom: 10px;
 `
 
 const LoaderWrapper = styled.div`
@@ -62,7 +62,8 @@ const HasNextLink = styled.button`
   align-items: center;
   justify-content: center;
   flex: 0 0 60px;
-  padding: 10px 0;
+  padding-top: 10px;
+  padding-bottom: 20px;
   text-transform: uppercase;
   color: ${({ theme }) => theme.colors.Search.nextButton};
 `

--- a/src/scripts/components/widgets/SearchResult.js
+++ b/src/scripts/components/widgets/SearchResult.js
@@ -66,16 +66,16 @@ const Info = styled.div`
   flex: 1 1 0;
   max-width: calc(100% - ${THUMBNAIL_WIDTH});
   height: 100%;
-  display: flex;
-  flex-direction: column;
   padding: 10px;
   padding-bottom: 20px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.Search.results.border};
 `
 
+const TOP_BAR_HEIGHT: string = '25px'
+
 const TopBar = styled.div`
   width: 100%;
-  flex: 0 0 auto;
+  height: ${TOP_BAR_HEIGHT};
   display: flex;
 `
 
@@ -88,7 +88,7 @@ const Title = styled.div`
 `
 
 const BottomBar = styled.div`
-  flex: 1 1 0;
+  height: calc(100% - ${TOP_BAR_HEIGHT});
   display: flex;
   align-items: flex-end;
   color: ${({ theme }) => theme.colors.Search.results.descriptionColor};
@@ -98,7 +98,10 @@ const Description = styled.p`
   display: block;
   font-size: 16px;
   max-height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
 `
 
 type Props = {

--- a/src/scripts/components/widgets/SearchResult.js
+++ b/src/scripts/components/widgets/SearchResult.js
@@ -95,12 +95,14 @@ const BottomBar = styled.div`
 `
 
 const Description = styled.p`
-  display: block;
   font-size: 16px;
   max-height: 100%;
   overflow: hidden;
+  display: block;
+  /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
   -webkit-line-clamp: 5;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
   -webkit-box-orient: vertical;
 `
 


### PR DESCRIPTION
**Issue**
#130 

**Fixes**
- prevent text overflow in firefox
![image](https://user-images.githubusercontent.com/7697924/39609163-b6d9581a-4f14-11e8-8314-2d7acc3afad8.png)

- add multi-line text ellipsis in chrome/safari (in firefox the text just stops w/ no ellipsis):
![image](https://user-images.githubusercontent.com/7697924/39609178-d1894a4e-4f14-11e8-8893-9df04e947619.png)

- remove scroll from search result description and search results wrapper
