### PR TITLE
539 - increase video duration font-size in search results

### DIFF
--- a/src/scripts/components/widgets/SearchResult.js
+++ b/src/scripts/components/widgets/SearchResult.js
@@ -58,7 +58,7 @@ const Duration = styled.div`
   color: ${({ theme }) => theme.colors.Search.results.duration.text};
   background: ${({ theme }) => theme.colors.Search.results.duration.background};
   padding: 4px;
-  font-size: 10px;
+  font-size: 16px;
   text-align: center;
 `
 


### PR DESCRIPTION
**Issue**
#539 

**Work Done**
- increase video duration font-size

**Screenshot**

![image](https://user-images.githubusercontent.com/7697924/39676726-52850abe-513d-11e8-87db-5e714c088431.png)

@pedrocasa just FYI, the font-sizes in adobe are generally too small, in that if we use those pixel sizes they look much too small in a real browser. Perhaps the resolution of the adobe specs could be changed to help fix this?