### PR TITLE
546 - Wrong mnemonic check

### DIFF
--- a/src/scripts/components/widgets/modals/ModalRestoreAccount.js
+++ b/src/scripts/components/widgets/modals/ModalRestoreAccount.js
@@ -57,7 +57,7 @@ class ModalRewriteSeed extends Component<Props, Object> {
 
   restoreWallet () {
     const mnemonic = this.state.mnemonic
-    if (paratii.eth.wallet.isValidMnemonic) {
+    if (paratii.eth.wallet.isValidMnemonic(mnemonic)) {
       this.props.restoreKeystore(mnemonic)
       this.props.openModal(MODAL.CREATE_PASSWORD)
     } else {

--- a/src/scripts/types/ApplicationTypes.js
+++ b/src/scripts/types/ApplicationTypes.js
@@ -150,6 +150,7 @@ export type ParatiiLib = {
       getMnemonic: () => Promise<string>,
       create: (num: ?number, mnemonic: ?string) => Object,
       clear: () => void,
+      isValidMnemonic: string => boolean,
       length: number
     },
     vids: {


### PR DESCRIPTION
i've forgot to pass the mnemonic to check to `paratii.eth.wallet.isValidMnemonic`