### PR TITLE
572 - filter searches by staking status

### DIFF
--- a/src/scripts/actions/SearchActions.js
+++ b/src/scripts/actions/SearchActions.js
@@ -48,7 +48,8 @@ export const searchForVideos = ({ keyword }: Object = {}) => async (
       const searchResults: SearchResults = await paratii.vids.search({
         keyword,
         limit: SEARCH_BATCH_SIZE,
-        offset: 0
+        offset: 0,
+        staked: true
       })
       const results: Array<VideoInfo> = searchResults.results
       dispatch(
@@ -78,7 +79,8 @@ export const searchForMoreVideos = () => async (
       const searchResults: SearchResults = await paratii.vids.search({
         keyword,
         limit: SEARCH_BATCH_SIZE,
-        offset: nextSearchOffset
+        offset: nextSearchOffset,
+        staked: true
       })
 
       const results: Array<VideoInfo> = searchResults.results || []


### PR DESCRIPTION
⚠️ this is likely dependent on this [paratii-db issue](https://github.com/Paratii-Video/paratii-
db/issues/133) being resolved ⚠️ 

☝️ despite the above warning, I do think the `staked` filter is working in the db api already.

**Issue**
#572 

**Work Done**
- When searching for videos, filter by `staked: true`