### PR TITLE
571 - require username in account flow

### DIFF
--- a/src/scripts/components/widgets/modals/Modal.js
+++ b/src/scripts/components/widgets/modals/Modal.js
@@ -112,27 +112,13 @@ export const ModalScrollContent = styled.div`
 `
 
 class Modal extends Component<Props, void> {
-  renderModal () {
-    const { modalContent } = this.props
-    switch (modalContent) {
-      case MODAL.STAKE:
-        return <ModalStake />
-      case MODAL.SECURE:
-        return <ModalSecure />
-      case MODAL.GREAT_POWER:
-        return <ModalGreatPower />
-      case MODAL.CREATE_PASSWORD:
-        return <ModalCreatePassword />
-      case MODAL.ASK_PASSWORD:
-        return <ModalAskPassword />
-      case MODAL.SHOW_SEED:
-        return <ModalShowSeed />
-      case MODAL.PROFILE:
-        return <ModalProfile />
-      case MODAL.REWRITE_SEED:
-        return <ModalRewriteSeed />
-      case MODAL.RESTORE_ACCOUNT:
-        return <ModalRestoreAccount />
+  canClose = () => {
+    return this.props.modalContent !== MODAL.PROFILE
+  }
+
+  close = () => {
+    if (this.canClose()) {
+      this.props.closeModal()
     }
   }
 
@@ -164,29 +150,56 @@ class Modal extends Component<Props, void> {
 
   handleKeydown = (e: Event): void => {
     if (event.keyCode === 27) {
-      this.props.closeModal()
+      this.close()
     }
   }
 
   componentDidMount () {
-    document.addEventListener('keydown', this.handleKeydown.bind(this))
+    document.addEventListener('keydown', this.handleKeydown)
   }
 
   componentWillUnmount () {
-    document.removeEventListener('keydown', this.handleKeydown.bind(this))
+    document.removeEventListener('keydown', this.handleKeydown)
+  }
+
+  renderModal () {
+    const { modalContent } = this.props
+    switch (modalContent) {
+      case MODAL.STAKE:
+        return <ModalStake />
+      case MODAL.SECURE:
+        return <ModalSecure />
+      case MODAL.GREAT_POWER:
+        return <ModalGreatPower />
+      case MODAL.CREATE_PASSWORD:
+        return <ModalCreatePassword />
+      case MODAL.ASK_PASSWORD:
+        return <ModalAskPassword />
+      case MODAL.SHOW_SEED:
+        return <ModalShowSeed />
+      case MODAL.PROFILE:
+        return <ModalProfile />
+      case MODAL.REWRITE_SEED:
+        return <ModalRewriteSeed />
+      case MODAL.RESTORE_ACCOUNT:
+        return <ModalRestoreAccount />
+    }
   }
 
   render () {
     const isVisible = this.props.showModal
+
     return (
       <Wrapper show={isVisible}>
         <Container show={isVisible} width={this.getModalWidth()}>
-          <CloseButton onClick={this.props.closeModal}>
-            <SVGIcon icon="icon-close" />
-          </CloseButton>
+          {this.canClose() && (
+            <CloseButton onClick={this.close}>
+              <SVGIcon icon="icon-close" />
+            </CloseButton>
+          )}
           <Content>{this.renderModal()}</Content>
         </Container>
-        <Background show={isVisible} onClick={this.props.closeModal} />
+        <Background show={isVisible} onClick={this.close} />
       </Wrapper>
     )
   }

--- a/src/scripts/components/widgets/modals/ModalProfile.js
+++ b/src/scripts/components/widgets/modals/ModalProfile.js
@@ -8,7 +8,8 @@ import Text from 'components/foundations/Text'
 import Button from 'components/foundations/Button'
 import NotepadSvg from 'components/foundations/svgs/NotepadSvg'
 import { ModalContentWrapper, ModalScrollContent } from './Modal'
-import { MODAL } from 'constants/ModalConstants'
+
+const FORM_ID: string = 'PROFILE_MODAL'
 
 type Props = {
   openModal: string => void,
@@ -34,9 +35,8 @@ const Icon = styled.div`
   width: 100%;
 `
 
-class ModalSetPassword extends Component<Props, Object> {
+class ModalProfile extends Component<Props, Object> {
   setProfile: () => void
-  goBack: () => void
   handleInputChange: (input: string, e: Object) => void
 
   constructor (props: Props) {
@@ -47,15 +47,12 @@ class ModalSetPassword extends Component<Props, Object> {
       error: ''
     }
     this.setProfile = this.setProfile.bind(this)
-    this.goBack = this.goBack.bind(this)
     this.handleInputChange = this.handleInputChange.bind(this)
   }
 
-  goBack () {
-    this.props.openModal(MODAL.SHOW_SEED)
-  }
+  setProfile (e: Object) {
+    e.preventDefault()
 
-  setProfile () {
     if (this.state.email) {
       paratii.users.create({
         id: paratii.eth.getAccount(), // must be a valid ethereum address
@@ -93,24 +90,26 @@ class ModalSetPassword extends Component<Props, Object> {
           <Icon>
             <NotepadSvg />
           </Icon>
-          <TextField
-            error={this.state.error.length > 0}
-            label="Username"
-            name="username"
-            type="text"
-            value={this.state.username}
-            onChange={e => this.handleInputChange('username', e)}
-            margin="0 0 30px"
-          />
-          <TextField
-            error={this.state.error.length > 0}
-            label="Email"
-            name="email"
-            type="text"
-            value={this.state.email}
-            onChange={e => this.handleInputChange('email', e)}
-            margin="0 0 30px"
-          />
+          <form id={FORM_ID} onSubmit={this.setProfile}>
+            <TextField
+              error={this.state.error.length > 0}
+              label="Username"
+              name="username"
+              type="text"
+              value={this.state.username}
+              onChange={e => this.handleInputChange('username', e)}
+              margin="0 0 30px"
+            />
+            <TextField
+              error={this.state.error.length > 0}
+              label="Email"
+              name="email"
+              type="text"
+              value={this.state.email}
+              onChange={e => this.handleInputChange('email', e)}
+              margin="0 0 30px"
+            />
+          </form>
 
           {this.state.error && (
             <Text pink small>
@@ -120,9 +119,10 @@ class ModalSetPassword extends Component<Props, Object> {
           <Footer>
             <ButtonContainer>
               <Button
+                type="submit"
+                form={FORM_ID}
                 data-test-id="continue"
                 purple
-                onClick={this.setProfile}
                 disabled={!this.state.username}
               >
                 Continue
@@ -135,4 +135,4 @@ class ModalSetPassword extends Component<Props, Object> {
   }
 }
 
-export default ModalSetPassword
+export default ModalProfile


### PR DESCRIPTION
**Issue**
#571 

**Work Done**
- prevent user from closing username/email modal until they have entered a username

**Demo**

![usernamewin](https://user-images.githubusercontent.com/7697924/40089630-af4bbaa6-587a-11e8-8afa-72e1fa5e5a1b.gif)
