### PR TITLE
609 - add email verify notification and checkmark

### DIFF
--- a/src/scripts/components/App.js
+++ b/src/scripts/components/App.js
@@ -21,12 +21,12 @@ import Notifications from 'containers/NotificationContainer'
 import type { Match } from 'react-router-dom'
 import MainTemplate from './templates/MainTemplate'
 import Modal from 'containers/widgets/modals/ModalContainer'
+import MailVerifyContainer from 'containers/pages/MailVerifyContainer'
 import Main from './structures/Main'
 import MainFooter from './structures/footer/MainFooter'
 import Home from './pages/Home'
 import Voucher from './pages/Voucher'
 import NotFound from './pages/NotFound'
-import MailVerify from './pages/MailVerify'
 
 import { APP_TITLE, paratiiTheme } from 'constants/ApplicationConstants'
 
@@ -86,7 +86,10 @@ class App extends Component<Props, State> {
             <Main>
               <Switch>
                 <Route exact path="/" component={Home} />
-                <Route path={`${match.url}verify`} component={MailVerify} />
+                <Route
+                  path={`${match.url}verify`}
+                  component={MailVerifyContainer}
+                />
                 <Route
                   path={`${match.url}signup`}
                   component={SignupContainer}

--- a/src/scripts/components/Profile.js
+++ b/src/scripts/components/Profile.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import Blockies from 'react-blockies'
@@ -7,6 +7,7 @@ import { ACTIVATE_SECURE_WALLET } from 'constants/ParatiiLibConstants'
 import Colors from './foundations/base/Colors'
 import Button from './foundations/Button'
 import Text from './foundations/Text'
+import CheckIcon from './widgets/CheckIcon'
 import TruncatedText from './foundations/TruncatedText'
 import SVGIcon from './foundations/SVGIcon'
 import HR from './foundations/HR'
@@ -16,13 +17,12 @@ import {
   NOTIFICATION_LEVELS,
   NOTIFICATION_POSITIONS
 } from 'constants/ApplicationConstants'
+import User from 'records/UserRecords'
+import { getEmail, getEmailIsVerified, getName } from 'operators/UserOperators'
 import type { Notification, NotificationLevel } from 'types/ApplicationTypes'
 
 type Props = {
-  user: {
-    email: string,
-    name: string
-  },
+  user: User,
   userAddress: string,
   isWalletSecured: boolean,
   checkUserWallet: () => void,
@@ -56,6 +56,15 @@ const ProfileAvatar = styled.div`
 
 const FooterWrapper = styled.div`
   width: 100%;
+`
+
+const EmailAddressWrapper = styled.span`
+  margin-right: 10px;
+`
+
+const EmailDataWrapper = styled.div`
+  display: flex;
+  align-items: center;
 `
 
 const WordsWrapper = styled.div`
@@ -128,8 +137,21 @@ class Profile extends Component<Props, void> {
     }
     const cardFooter = (
       <FooterWrapper>
+        {getEmail(user) && (
+          <Fragment>
+            <Text gray small>
+              Email
+            </Text>
+            <Text data-test-id="profile-email" margin="0 0 20px 0">
+              <EmailDataWrapper>
+                <EmailAddressWrapper>{getEmail(user)}</EmailAddressWrapper>{' '}
+                {getEmailIsVerified(user) && <CheckIcon />}
+              </EmailDataWrapper>
+            </Text>
+          </Fragment>
+        )}
         <Text gray small>
-          Address:
+          Address
         </Text>
         <WordsWrapper>
           <CopyText
@@ -160,10 +182,7 @@ class Profile extends Component<Props, void> {
               <EditProfileButton to="/profile/edit">Edit</EditProfileButton>
               <ProfileAvatar>{userAvatar}</ProfileAvatar>
               <Text bold small>
-                {user.name}
-              </Text>
-              <Text data-test-id="profile-email" gray small>
-                {user.email}
+                {getName(user)}
               </Text>
               <Text tiny gray>
                 Since 2018

--- a/src/scripts/components/foundations/Text.js
+++ b/src/scripts/components/foundations/Text.js
@@ -50,4 +50,5 @@ export default styled.p`
   overflow-wrap: break-word;
   white-space: pre-wrap;
   word-wrap: break-word;
+  margin: ${({ margin }) => margin};
 `

--- a/src/scripts/components/pages/MailVerify.js
+++ b/src/scripts/components/pages/MailVerify.js
@@ -59,8 +59,7 @@ class MailVerify extends Component<Props, State> {
         const response = JSON.parse(xhttp.responseText)
         if (response.events && response.events.LogDistribute) {
           const redeemWei = response.events.LogDistribute.returnValues._amount
-          const redeemPTI =
-            10 || paratii.eth.web3.utils.fromWei(String(redeemWei))
+          const redeemPTI = paratii.eth.web3.utils.fromWei(String(redeemWei))
           this.setState({
             message: `You have earned ${redeemPTI} PTI`,
             error: ''

--- a/src/scripts/components/pages/MailVerify.js
+++ b/src/scripts/components/pages/MailVerify.js
@@ -53,7 +53,7 @@ class MailVerify extends Component<Props, State> {
     xhttp.onreadystatechange = (event: Object) => {
       if (
         event.currentTarget.readyState === 4 &&
-        event.cusucrrentTarget.status === 200
+        event.currentTarget.status === 200
       ) {
         // Notification mail sent!
         const response = JSON.parse(xhttp.responseText)

--- a/src/scripts/components/pages/MailVerify.js
+++ b/src/scripts/components/pages/MailVerify.js
@@ -1,8 +1,19 @@
+/* flow */
+
 import React, { Component } from 'react'
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
 import paratii from 'utils/ParatiiLib'
 import Title from '../foundations/Title'
 import Text from '../foundations/Text'
-import styled from 'styled-components'
+import Loader from '../foundations/Loader'
+import {
+  NOTIFICATION_LEVELS,
+  NOTIFICATION_POSITIONS
+} from 'constants/ApplicationConstants'
+
+import type { Notification, NotificationLevel } from 'types/ApplicationTypes'
 
 const Wrapper = styled.div`
   display: flex;
@@ -13,16 +24,26 @@ const Wrapper = styled.div`
   max-width: 710px;
   width: 100%;
 `
-type Props = {}
+
+type Props = {
+  showNotification: (Notification, NotificationLevel) => void
+}
+
+type State = {
+  message: string,
+  error: string,
+  requestInitiated: boolean
+}
 
 // const NavLink = Button.withComponent('a')
 
-class MailVerify extends Component<Props, void> {
+class MailVerify extends Component<Props, State> {
   constructor (props: Props) {
     super(props)
     this.state = {
       message: '',
-      error: ''
+      error: '',
+      requestInitiated: false
     }
   }
 
@@ -32,28 +53,63 @@ class MailVerify extends Component<Props, void> {
     xhttp.onreadystatechange = (event: Object) => {
       if (
         event.currentTarget.readyState === 4 &&
-        event.currentTarget.status === 200
+        event.cusucrrentTarget.status === 200
       ) {
         // Notification mail sent!
         const response = JSON.parse(xhttp.responseText)
-        console.log(response)
         if (response.events && response.events.LogDistribute) {
           const redeemWei = response.events.LogDistribute.returnValues._amount
-          const redeemPTI = paratii.eth.web3.utils.fromWei(String(redeemWei))
+          const redeemPTI =
+            10 || paratii.eth.web3.utils.fromWei(String(redeemWei))
           this.setState({
             message: `You have earned ${redeemPTI} PTI`,
             error: ''
           })
+
+          this.props.showNotification(
+            {
+              title: 'Email Confirmed!',
+              message: `Your email has been confirmed. You have earned ${redeemPTI}, use it wisely.`,
+              position: NOTIFICATION_POSITIONS.TOP_RIGHT
+            },
+            NOTIFICATION_LEVELS.SUCCESS
+          )
         } else {
           this.setState({
             message: 'An error occured',
             error: 'An error occured'
           })
+
+          this.props.showNotification(
+            {
+              title: 'Error confirming email',
+              message: 'We have encountered an unexpected error.',
+              position: NOTIFICATION_POSITIONS.TOP_RIGHT
+            },
+            NOTIFICATION_LEVELS.ERROR
+          )
         }
       }
     }
     xhttp.open('GET', `/mail/verify/?${query}`, true)
+    this.setState({ requestInitiated: true })
     xhttp.send()
+  }
+
+  renderContents () {
+    const { error, requestInitiated } = this.state
+
+    if (!requestInitiated) {
+      return <Loader />
+    }
+
+    return (
+      !error && (
+        <Text gray>
+          Please <Link to="/profile">log in</Link> to check your balance
+        </Text>
+      )
+    )
   }
 
   render () {
@@ -61,11 +117,7 @@ class MailVerify extends Component<Props, void> {
       <Wrapper>
         <Title purple>Mail verification</Title>
         <Text gray>{this.state.message}</Text>
-        {!this.state.error && (
-          <Text gray>
-            Please <a href="/profile">log in</a> to check your balance
-          </Text>
-        )}
+        {this.renderContents()}
       </Wrapper>
     )
   }

--- a/src/scripts/components/widgets/CheckIcon.js
+++ b/src/scripts/components/widgets/CheckIcon.js
@@ -12,7 +12,7 @@ const WrapperSvg = styled.svg`
   border-radius: 50%;
   height: ${DIMENSION_PX}px;
   width: ${DIMENSION_PX}px;
-  padding: px;
+  padding: 1px;
 `
 
 const CheckIcon = () => (

--- a/src/scripts/components/widgets/CheckIcon.js
+++ b/src/scripts/components/widgets/CheckIcon.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+import React from 'react'
+import styled from 'styled-components'
+
+import Colors from 'components/foundations/base/Colors'
+
+const DIMENSION_PX = 17
+
+const WrapperSvg = styled.svg`
+  background-color: ${Colors.purple};
+  border-radius: 50%;
+  height: ${DIMENSION_PX}px;
+  width: ${DIMENSION_PX}px;
+  padding: px;
+`
+
+const CheckIcon = () => (
+  <WrapperSvg>
+    <use xlinkHref="#icon-check" />
+  </WrapperSvg>
+)
+
+export default CheckIcon

--- a/src/scripts/components/widgets/modals/ModalProfile.js
+++ b/src/scripts/components/widgets/modals/ModalProfile.js
@@ -87,7 +87,7 @@ class ModalProfile extends Component<Props, Object> {
         // Notification mail sent!
         this.props.notification(
           {
-            title: 'Check you email!',
+            title: 'Check your email!',
             message: 'We sent you a confirmation link',
             autoDismiss: 0
           },

--- a/src/scripts/containers/pages/MailVerifyContainer.js
+++ b/src/scripts/containers/pages/MailVerifyContainer.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+import { connect } from 'react-redux'
+import { show } from 'react-notification-system-redux'
+
+import MailVerify from 'components/pages/MailVerify'
+
+const mapDispatchToProps = {
+  showNotification: show
+}
+
+export default connect(undefined, mapDispatchToProps)(MailVerify)

--- a/src/scripts/operators/UserOperators.js
+++ b/src/scripts/operators/UserOperators.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+import User from 'records/UserRecords'
+
+export const getEmail = (user: User): string => user.get('email')
+
+export const getEmailIsVerified = (user: User): boolean =>
+  user.get('emailIsVerified')
+
+export const getName = (user: User): string => user.get('name')

--- a/src/scripts/records/UserRecords.js
+++ b/src/scripts/records/UserRecords.js
@@ -16,6 +16,7 @@ class User extends Immutable.Record({
   address: '',
   name: '',
   email: '',
+  emailIsVerified: false,
   keepUrl: true,
   walletKey: 'keystore-anon',
   mnemonicKey: 'mnemonic-anon',
@@ -25,6 +26,7 @@ class User extends Immutable.Record({
   address: string
   name: string
   email: string
+  emailIsVerified: boolean
   keepUrl: boolean
   walletKey: string
   mnemonicKey: string

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,6 +65,7 @@ const config = {
       components: scriptsDir + '/components',
       constants: scriptsDir + '/constants',
       actions: scriptsDir + '/actions',
+      operators: scriptsDir + '/operators',
       reducers: scriptsDir + '/reducers',
       records: scriptsDir + '/records',
       containers: scriptsDir + '/containers',


### PR DESCRIPTION
⚠️ I was not able to actually get this flow to work; the gif below is using stubbed in data ⚠️ 

**NOTES**
- is it expected that when I verify my email I have to restore my account via a mnemonic? I would expect that I could just enter my password.

**Issue**
#609 

**Work Done**
- move email in profile page
- add checkmark next to verified emails
- add notification when you hit `/verify` route, on success or error

![image](https://user-images.githubusercontent.com/7697924/40572886-6a5384d4-6085-11e8-92b2-3975cbcb4eb7.png)


![verifywin](https://user-images.githubusercontent.com/7697924/40572860-f1ba5656-6084-11e8-8bbf-e73b0150337d.gif)

