### PR TITLE
589 player time fix

### DIFF
--- a/src/scripts/selectors/PlayerSelectors.js
+++ b/src/scripts/selectors/PlayerSelectors.js
@@ -33,19 +33,6 @@ export const getPlayingVideo: (
   }
 )
 
-export const getFormattedCurrentTime: (
-  state: RootState
-) => string = createSelector(
-  [getPlayerCurrentTimeSeconds],
-  (currentTimeSeconds: number): string => {
-    const roundedTime: number = Math.floor(currentTimeSeconds)
-    return TimeFormat.fromS(
-      roundedTime,
-      roundedTime >= 3600 ? 'hh:mm:ss' : 'mm:ss'
-    )
-  }
-)
-
 export const getFormattedDuration: (
   state: RootState
 ) => string = createSelector(
@@ -53,6 +40,23 @@ export const getFormattedDuration: (
   (playingVideo: ?VideoRecord): string => {
     const duration: ?string = playingVideo && playingVideo.get('duration')
     return formatDuration(duration)
+  }
+)
+
+export const getFormattedCurrentTime: (
+  state: RootState
+) => string = createSelector(
+  [getPlayerCurrentTimeSeconds, getFormattedDuration],
+  (currentTimeSeconds: number, formattedDuration: string): string => {
+    const roundedTime: number = Math.floor(currentTimeSeconds)
+    const formattedCurrentTime: string = TimeFormat.fromS(
+      roundedTime,
+      roundedTime >= 3600 ? 'hh:mm:ss' : 'mm:ss'
+    )
+
+    return formattedDuration < formattedCurrentTime
+      ? formattedDuration
+      : formattedCurrentTime
   }
 )
 

--- a/test/unit-tests/.eslintrc
+++ b/test/unit-tests/.eslintrc
@@ -1,3 +1,3 @@
 "env": {
-  "jasmine": true
+  "mocha": true
 }

--- a/test/unit-tests/selectors/PlayerSelectors.test.js
+++ b/test/unit-tests/selectors/PlayerSelectors.test.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { Map } from 'immutable'
+import { expect } from 'chai'
 
 import mockGetState from 'unit-tests/test-utils/mockGetState'
 

--- a/test/unit-tests/selectors/PlayerSelectors.test.js
+++ b/test/unit-tests/selectors/PlayerSelectors.test.js
@@ -1,0 +1,49 @@
+/* @flow */
+
+import { Map } from 'immutable'
+
+import mockGetState from 'unit-tests/test-utils/mockGetState'
+
+import Player from 'records/PlayerRecords'
+import Video from 'records/VideoRecords'
+
+import * as PlayerSelectors from 'selectors/PlayerSelectors'
+
+const defaultVideosMap = Map({
+  '987': new Video({
+    duration: '10:22'
+  }),
+  '123': new Video({
+    duration: '05:24'
+  })
+})
+
+describe('PlayerSelectors', () => {
+  describe('getFormattedCurrentTime', () => {
+    it('should format the current time in the player correctly', () => {
+      const getState = mockGetState({
+        player: new Player({
+          currentTimeSeconds: 120,
+          selectedVideoId: '123'
+        }),
+        videos: defaultVideosMap
+      })
+      expect(PlayerSelectors.getFormattedCurrentTime(getState())).to.equal(
+        '02:00'
+      )
+    })
+
+    it('should return the formatted video duration if the current player time is great than the duration', () => {
+      const getState = mockGetState({
+        player: new Player({
+          currentTimeSeconds: 9999999,
+          selectedVideoId: '123'
+        }),
+        videos: defaultVideosMap
+      })
+      expect(PlayerSelectors.getFormattedCurrentTime(getState())).to.equal(
+        '05:24'
+      )
+    })
+  })
+})


### PR DESCRIPTION
⚠️ perhaps do not merge this yet as I haven't been able to test it in the browser, since the dev env is broken at the moment ⚠️ 

**Issue**
#589 

**Work Done**
- Enforce that the rendered current video time does not exceed the video duration. Due to rounding errors, it is possible that this number unexpectedly exceeds duration, so we needed to account for this.

