### PR TITLE
Extend timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,9 @@ jobs:
       - run:
           command: yarn run server:test
           background: true
-      - run: node src/scripts/waitForServer.js
+      - run:
+          command: node src/scripts/waitForServer.js
+          no_output_timeout: 120000
       - run: yarn run chimp-circleci-test
       - deploy:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           background: true
       - run:
           command: node src/scripts/waitForServer.js
-          no_output_timeout: 120000
+          no_output_timeout: 120s
       - run: yarn run chimp-circleci-test
       - deploy:
           command: |


### PR DESCRIPTION
**Work Done**
- allow `waitForServer` task on `CircleCI` to take up to two minutes