### PR TITLE
adding repo path for production client

### DIFF
--- a/config/production-client.json
+++ b/config/production-client.json
@@ -5,5 +5,8 @@
   },
   "db": {
     "provider": "https://db.paratii.video/api/v1/"
+  },
+  "ipfs": {
+    "repo": "/tmp/paratii-repo-v0.2.6"
   }
 }


### PR DESCRIPTION
This is part of enhancing the uploader experience and allows users to continue receiving updates after a reload.