### PR TITLE
700 - fix time slider cutoff in player

### DIFF
--- a/src/scripts/components/PlayerControls.js
+++ b/src/scripts/components/PlayerControls.js
@@ -140,11 +140,13 @@ const Controls = styled.div`
   }
 `
 
+const CONTROL_BUTTONS_PADDING_X: string = '24px'
+
 const ProgressWrapper = styled.div`
   position: absolute;
   top: -9px;
   height: 20px;
-  width: 100%;
+  width: calc(100% - ${CONTROL_BUTTONS_PADDING_X});
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -156,7 +158,7 @@ const ControlButtons = styled.div`
   align-items: center;
   display: flex;
   flex-direction: row;
-  padding: 2px 24px 0;
+  padding: 2px ${CONTROL_BUTTONS_PADDING_X} 0;
   height: ${CONTROL_BUTTONS_HEIGHT};
 `
 


### PR DESCRIPTION
**Issue**
#700 

**Work Done**
- add some padding around player progress bar so that progress indicator is never cut off

![image](https://user-images.githubusercontent.com/7697924/41413668-c6a86a70-6fb1-11e8-8081-9a2a366d42ab.png)
