### PR TITLE
756 - regularly update account balance and update total staked

### DIFF
--- a/src/scripts/actions/AppActions.js
+++ b/src/scripts/actions/AppActions.js
@@ -1,13 +1,19 @@
 import { createAction } from 'redux-actions'
 
 import { INITIALIZE, SET_CONTEXT } from 'constants/ActionConstants'
-import { setupKeystore, setAddressAndBalance } from 'actions/UserActions'
+import { BALANCE_LOAD_INTERVAL_MS } from 'constants/UserConstants'
+import {
+  setupKeystore,
+  setAddressAndBalance,
+  loadBalancesOnInterval
+} from 'actions/UserActions'
 
 export const initializeWithData = createAction(INITIALIZE)
 
 export const initializeApp = () => (dispatch, getState) => {
   dispatch(setupKeystore())
   dispatch(setAddressAndBalance())
+  dispatch(loadBalancesOnInterval(BALANCE_LOAD_INTERVAL_MS))
 }
 
 export const setContext = createAction(SET_CONTEXT)

--- a/src/scripts/actions/UserActions.js
+++ b/src/scripts/actions/UserActions.js
@@ -84,6 +84,18 @@ export const loadBalances = () => (dispatch: Dispatch) => {
   }
 }
 
+let balanceLoadIntervalId: number = 0
+
+export const loadBalancesOnInterval = (intervalMs: number) => (
+  dispatch: Dispatch
+) => {
+  clearInterval(balanceLoadIntervalId)
+
+  balanceLoadIntervalId = setInterval(() => {
+    dispatch(loadBalances())
+  }, intervalMs)
+}
+
 export const totalStakedPTI = () => async (dispatch: Dispatch) => {
   const address: string = paratii.eth.getAccount()
   if (address) {

--- a/src/scripts/actions/UserActions.js
+++ b/src/scripts/actions/UserActions.js
@@ -96,7 +96,7 @@ export const loadBalancesOnInterval = (intervalMs: number) => (
   }, intervalMs)
 }
 
-export const totalStakedPTI = () => async (dispatch: Dispatch) => {
+export const loadTotalStakedPTI = () => async (dispatch: Dispatch) => {
   const address: string = paratii.eth.getAccount()
   if (address) {
     const totalBN = await paratii.eth.tcr.getTotalStaked(address)
@@ -130,7 +130,7 @@ export const setUserData = () => async (dispatch: Dispatch) => {
       })
     )
     // Get total Pti staked
-    dispatch(totalStakedPTI())
+    dispatch(loadTotalStakedPTI())
   }
 }
 

--- a/src/scripts/components/widgets/PTIBalance.js
+++ b/src/scripts/components/widgets/PTIBalance.js
@@ -8,8 +8,7 @@ import TruncatedText from 'components/foundations/TruncatedText'
 
 type Props = {
   balance: string,
-  color?: string,
-  loadBalances: () => void
+  color?: string
 }
 
 const Wrapper = styled.div`
@@ -23,24 +22,7 @@ const NumberWrapper = styled.span`
   display: flex;
 `
 
-// FIXME: the whole polling logic should be moved to its own dedicated place a
-// instead of being connected to  a particular component
-const REFRESH_BALANCES_INTERVAL_MS: number = 200000
-
 class PTIBalance extends React.Component<Props, void> {
-  intervalId: ?number
-
-  componentWillMount = (): void => {
-    const { loadBalances } = this.props
-    this.intervalId = setInterval(loadBalances, REFRESH_BALANCES_INTERVAL_MS)
-  }
-
-  componentWillUnmount = (): void => {
-    if (this.intervalId) {
-      clearInterval(this.intervalId)
-    }
-  }
-
   render () {
     const { balance, color } = this.props
 

--- a/src/scripts/components/widgets/modals/ModalStake.js
+++ b/src/scripts/components/widgets/modals/ModalStake.js
@@ -17,6 +17,7 @@ type Props = {
   saveVideoStaked: Object => Object,
   selectedVideo: Object => Object,
   notification: (Object, string) => void,
+  loadTotalStakedPTI: () => void,
   loadBalances: () => void
 }
 
@@ -65,7 +66,7 @@ class ModalStake extends Component<Props, Object> {
   }
 
   onSubmit (event: Object) {
-    const { loadBalances } = this.props
+    const { loadBalances, loadTotalStakedPTI } = this.props
     event.preventDefault()
     this.props.notification({ title: 'Processing...' }, 'warning')
     const stakeAmount = this.state.stakeAmount
@@ -101,6 +102,7 @@ class ModalStake extends Component<Props, Object> {
             'success'
           )
           loadBalances()
+          loadTotalStakedPTI()
         } else {
           const msg =
             'apply returns false :( , something went wrong at contract level. check balance, gas, all of that stuff.'

--- a/src/scripts/constants/UserConstants.js
+++ b/src/scripts/constants/UserConstants.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+export const BALANCE_LOAD_INTERVAL_MS: number = 2000

--- a/src/scripts/containers/widgets/modals/ModalStakeContainer.js
+++ b/src/scripts/containers/widgets/modals/ModalStakeContainer.js
@@ -9,7 +9,7 @@ import { getSelectedUploaderVideo } from 'selectors/UploaderSelectors'
 import { saveVideoStaked, uploadAndTranscode } from 'actions/UploaderActions'
 import { getUser } from 'selectors/index'
 import ModalStake from 'components/widgets/modals/ModalStake'
-import { loadBalances } from 'actions/UserActions'
+import { loadBalances, loadTotalStakedPTI } from 'actions/UserActions'
 
 import type { RootState } from 'types/ApplicationTypes'
 
@@ -23,6 +23,7 @@ const mapDispatchToProps = dispatch => ({
   uploadAndTranscode: bindActionCreators(uploadAndTranscode, dispatch),
   closeModal: bindActionCreators(closeModal, dispatch),
   notification: bindActionCreators(show, dispatch),
+  loadTotalStakedPTI: bindActionCreators(loadTotalStakedPTI, dispatch),
   loadBalances: bindActionCreators(loadBalances, dispatch)
 })
 


### PR DESCRIPTION
**Issue**
#756 
#763 

**Work Done**
- load account balance every 2 seconds
- remove polling logic from `<PTIBalance />` component and move the logic to the application itself
- update staking balance after making a stake (this balance is not updated every 2 seconds because I think this addl request is unnecessary. In general we should only have to update this balance when we explicitly make a stake on the FE)

**Demos**

👇 **balance**

![balanceupdate](https://user-images.githubusercontent.com/7697924/42421588-e401a058-82a5-11e8-8062-af7c525a37ab.gif)

☝️ resolution on the gif may not be great, but the gif is demonstrating that when we update the balance w/ `dev/faucet.js` the balance updates in the app immediately (and at worst, after 2 seconds)

👇 **total staked**

![stakewin](https://user-images.githubusercontent.com/7697924/42422345-6b44aae0-82b2-11e8-8ec7-3e2cc82685cb.gif)



