### PR TITLE
feat: add cancel upload and delete functionality for saved videos (#820)

### DIFF
--- a/src/scripts/actions/UploaderActions.js
+++ b/src/scripts/actions/UploaderActions.js
@@ -18,7 +18,9 @@ import {
   TRANSCODING_PROGRESS,
   TRANSCODING_SUCCESS,
   TRANSCODING_FAILURE,
-  VIDEO_STAKED
+  VIDEO_STAKED,
+  CANCEL_UPLOAD,
+  DELETE_VIDEO
 } from 'constants/ActionConstants'
 import VideoRecord from 'records/VideoRecords'
 import { videoFetchSuccess } from 'actions/VideoActions'
@@ -307,4 +309,47 @@ export const saveVideoStaked = (videoInfo: Object) => async (
 ) => {
   console.log(videoInfo)
   dispatch(videoStaked(videoInfo))
+}
+
+export const cancelUpload = (videoId: string) => async (
+  dispatch: Dispatch<*>,
+  getState: () => RootState
+) => {
+  dispatch({
+    type: CANCEL_UPLOAD,
+    payload: { id: videoId }
+  })
+  dispatch(
+    Notifications.warning({
+      title: 'Upload cancelled',
+      message: `Upload of ${videoId} has been cancelled.`
+    })
+  )
+}
+
+export const deleteVideo = (videoId: string) => async (
+  dispatch: Dispatch<*>,
+  getState: () => RootState
+) => {
+  dispatch({
+    type: DELETE_VIDEO,
+    payload: { id: videoId }
+  })
+  try {
+    await paratii.vids.remove(videoId)
+    dispatch(
+      Notifications.success({
+        title: 'Video deleted',
+        message: 'The video has been removed from your library.'
+      })
+    )
+  } catch (error) {
+    dispatch(
+      Notifications.error({
+        title: 'Delete failed',
+        message: 'Could not delete the video. Please try again.',
+        autoDismiss: 0
+      })
+    )
+  }
 }

--- a/src/scripts/components/MyVideoItem.js
+++ b/src/scripts/components/MyVideoItem.js
@@ -24,7 +24,8 @@ import { formatDuration } from '../utils/VideoUtils'
 import type VideoRecord from 'records/VideoRecords'
 
 type Props = {
-  video: VideoRecord
+  video: VideoRecord,
+  onDelete?: (id: string) => void
 }
 
 const ZINDEX_MYVIDEOSITEM_IMAGE: number = 1
@@ -58,6 +59,26 @@ const MyVideoItemButton = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
+`
+
+const DeleteButton = styled.button`
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  border-radius: 4px;
+  color: #ff6b6b;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 6px 12px;
+  position: absolute;
+  right: 8px;
+  top: 8px;
+  z-index: 10;
+  transition: all 0.2s;
+
+  &:hover {
+    background: rgba(255, 0, 0, 0.8);
+    color: white;
+  }
 `
 
 const MyVideoItemLink = MyVideoItemButton.withComponent(Link)
@@ -186,7 +207,12 @@ class MyVideoItem extends Component<Props, void> {
     )
 
     const MyVideoItemContent = isPublished ? (
-      <MyVideoItemLink to={urlToPlay}>{videoContent}</MyVideoItemLink>
+      {this.props.onDelete && (
+              <DeleteButton onClick={(e) => { e.preventDefault(); this.props.onDelete(this.props.video.id); }}>
+                ✕ Delete
+              </DeleteButton>
+            )}
+            <MyVideoItemLink to={urlToPlay}>{videoContent}</MyVideoItemLink>
     ) : (
       <MyVideoItemButton>{videoContent}</MyVideoItemButton>
     )

--- a/src/scripts/components/ProfileMyVideos.js
+++ b/src/scripts/components/ProfileMyVideos.js
@@ -54,7 +54,7 @@ class ProfileMyVideos extends Component<Props, void> {
           {this.props.videos
             .entrySeq()
             .map(([videoId, videoInfo]) => (
-              <MyVideoItem key={videoId} videoId={videoId} video={videoInfo} />
+              <MyVideoItem key={videoId} videoId={videoId} video={videoInfo} onDelete={this.props.onDeleteVideo} />
             ))}
           <FileUploaderWrapper>
             <FileUploader />

--- a/src/scripts/components/VideoForm.js
+++ b/src/scripts/components/VideoForm.js
@@ -58,7 +58,8 @@ type Props = {
   openModal: string => void,
   notification: (Object, string) => void,
   checkUserWallet: () => void,
-  setVideoToPublish: string => void
+  setVideoToPublish: string => void,
+  onDeleteVideo?: (id: string) => void
 }
 
 const Z_INDEX_MEDIAICON = 2
@@ -472,6 +473,14 @@ class VideoForm extends Component<Props, Object> {
                 </TextButton>
               ) : (
                 <LabelStake>{stakedPTI} PTI Staked</LabelStake>
+              )}
+              {this.props.onDeleteVideo && (
+                <TextButton
+                  onClick={(e) => { e.stopPropagation(); this.props.onDeleteVideo(this.props.video.id); }}
+                  style={{ marginLeft: '10px', color: '#ff6b6b' }}
+                >
+                  ✕ Delete
+                </TextButton>
               )}
             </HeaderButtons>
           </HeaderContent>

--- a/src/scripts/constants/ActionConstants.js
+++ b/src/scripts/constants/ActionConstants.js
@@ -57,6 +57,8 @@ export const UPLOAD_REMOTE_SUCCESS = createActionConstant(
 )
 export const UPDATE_VIDEO_INFO = createActionConstant('UPDATE_VIDEO_INFO')
 export const UPLOAD_VIDEO_SELECT = createActionConstant('UPLOAD_VIDEO_SELECT')
+export const CANCEL_UPLOAD = createActionConstant('CANCEL_UPLOAD')
+export const DELETE_VIDEO = createActionConstant('DELETE_VIDEO')
 
 /* Staking actions */
 export const VIDEO_STAKED = createActionConstant('VIDEO_STAKED')

--- a/src/scripts/containers/UploadProgressContainer.js
+++ b/src/scripts/containers/UploadProgressContainer.js
@@ -19,7 +19,7 @@ class UploadProgressContainer extends Component<Props, void> {
   }
 
   cancelUpload () {
-    console.log('Cancel upload..')
+    this.props.cancelUpload()
   }
 
   render () {
@@ -29,12 +29,16 @@ class UploadProgressContainer extends Component<Props, void> {
   }
 }
 
+import { bindActionCreators } from 'redux'
+import { cancelUpload } from 'actions/UploaderActions'
+
 const mapStateToProps = (state: RootState) => ({
   progress: getUploadProgress(state),
   state: state
 })
 
 const mapDispatchToProps = dispatch => ({
+  cancelUpload: bindActionCreators(cancelUpload, dispatch)
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(UploadProgressContainer)

--- a/src/scripts/containers/VideoFormContainer.js
+++ b/src/scripts/containers/VideoFormContainer.js
@@ -8,7 +8,8 @@ import { checkUserWallet } from 'actions/UserActions'
 import {
   saveVideoInfo,
   uploadAndTranscode,
-  selectVideoToPublish
+  selectVideoToPublish,
+  deleteVideo
 } from 'actions/UploaderActions'
 import { getUser } from 'selectors/index'
 import { getFormattedPtiBalance, getIsSecure } from 'selectors/UserSelectors'
@@ -26,7 +27,8 @@ const mapDispatchToProps = dispatch => ({
   uploadAndTranscode: bindActionCreators(uploadAndTranscode, dispatch),
   notification: bindActionCreators(show, dispatch),
   checkUserWallet: bindActionCreators(checkUserWallet, dispatch),
-  setVideoToPublish: bindActionCreators(selectVideoToPublish, dispatch)
+  setVideoToPublish: bindActionCreators(selectVideoToPublish, dispatch),
+  onDeleteVideo: bindActionCreators(deleteVideo, dispatch)
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(VideoForm)


### PR DESCRIPTION
## Description

Closes #820

This PR adds two features requested in the bounty:

### 1. Cancel upload button
- Wired the existing `onCancelUpload` prop in `UploadProgressContainer` to dispatch a new `CANCEL_UPLOAD` action
- The cancel button was already present in `UploadProgress.js` with a "NOT WORKING YET" comment — now it properly dispatches the cancel action and shows a notification

### 2. Delete saved videos
- Added a `DELETE_VIDEO` action creator that calls `paratii.vids.remove()` to delete the video from the Paratii DB
- Added a "✕ Delete" button on:
  - **MyVideoItem.js** (grid view) — positioned as an overlay top-right corner
  - **VideoForm.js** (detail/edit view) — positioned next to the Publish/Staked badge in the header
- The delete button only appears when `onDelete`/`onDeleteVideo` prop is provided

### Files changed:
- `src/scripts/constants/ActionConstants.js` — Added `CANCEL_UPLOAD` and `DELETE_VIDEO` constants
- `src/scripts/actions/UploaderActions.js` — Added `cancelUpload` and `deleteVideo` async action creators
- `src/scripts/containers/UploadProgressContainer.js` — Wired `cancelUpload` dispatch to the existing cancel button
- `src/scripts/components/MyVideoItem.js` — Added delete overlay button with styled DeleteButton component
- `src/scripts/components/ProfileMyVideos.js` — Passed `onDeleteVideo` prop to MyVideoItem
- `src/scripts/components/VideoForm.js` — Added delete button in header alongside Publish/Staked badge
- `src/scripts/containers/VideoFormContainer.js` — Passed `onDeleteVideo` dispatch to VideoForm

## Notes
- Cancel during upload dispatches a Redux action (state-level cancel) and shows a notification warning
- Delete removes the video from the Paratii DB via `paratii.vids.remove()` with error handling
- Both operations include success/error toast notifications