### PR TITLE
feat: Add file size restriction messaging for uploads (#718)

### DIFF
--- a/src/scripts/components/widgets/FileUploader.js
+++ b/src/scripts/components/widgets/FileUploader.js
@@ -13,7 +13,7 @@ import SVGIcon from '../foundations/SVGIcon'
 import FilesUploaderSvg from '../foundations/svgs/FilesUploaderSvg'
 import TranslatedText from '../translations/TranslatedText'
 import RawTranslatedText from 'utils/translations/RawTranslatedText'
-import { SUPPORTED_FILE_TYPES } from 'constants/UploaderConstants'
+import { SUPPORTED_FILE_TYPES, MAX_FILE_SIZE } from 'constants/UploaderConstants'
 
 type Props = {
   history: RouterHistory,
@@ -119,6 +119,21 @@ class FilesUploader extends Component<Props, Object> {
     if (this.props.isWalletSecured) {
       const file = e.target.files[0]
       if (file) {
+        // Validate file type and size before proceeding
+        const isValidType = SUPPORTED_FILE_TYPES.includes(file.type)
+        const isValidSize = file.size <= MAX_FILE_SIZE
+        if (!isValidType) {
+          this.setState({
+            fileName: 'Unsupported file format. Please use .mp4 files.'
+          })
+          return
+        }
+        if (!isValidSize) {
+          this.setState({
+            fileName: 'File too large. Maximum size is 2GB.'
+          })
+          return
+        }
         this.props.onFileChosen(file)
         this.setState({
           file: file,

--- a/src/scripts/constants/UploaderConstants.js
+++ b/src/scripts/constants/UploaderConstants.js
@@ -1,3 +1,4 @@
 /* @flow */
 
 export const SUPPORTED_FILE_TYPES = ['video/mp4']
+export const MAX_FILE_SIZE = 2 * 1024 * 1024 * 1024 // 2GB

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,370 +1,374 @@
 {
-	"footer": {
-		"discover_html": "Learn more about Paratii at %{homePageLink}",
-		"homePage": "paratii.video",
-		"betaTool_html": "v0.0.2: This is an alpha tool! We &hearts; to get feedback on Telegram: %{telegramBrazilLink} or %{telegramEnglishLink}",
-		"brazil": "Portuguese",
-		"english": "English"
-	},
-	"landingPage": {
-		"alert_html": "<strong>Alpha product</strong> (on an Ethereum testnet). Code hasn’t been audited. Don’t share sensitive information.",
-		"header": {
-			"title_html": "🎉 Around the block:<br /> Episode 2 is live",
-			"description_html": "A 4-part docuseries on the story of crypto-land.<br /> 👇 Start watching now!",
-			"button": "Ep."
-		},
-		"text": "Lab is a peer-to-peer video site that doesn't spy on you. Find series, tutorials, speeches and discover crypto-communities beyond your own.",
-		"button": "+ Discover more",
-		"videos": {
-			"title": "Meet your fellow pioneers",
-			"description": "Explore short stories, music clips, and formats that our community is inventing every day."
-		}
-	},
-	"modal": {
-		"challenge": {
-			"title": "Challenge this video"
-		},
-		"profile": {
-			"title": "Profile",
-			"description": "This is how you'll be known. Enter your email to receive updates about the community and your activity.",
-			"usernameLabel": "Username",
-			"emailLabel": "Email",
-			"continue": "Continue",
-			"pleaseWait": "Please wait: creating your wallet.",
-			"verificationEmail": {
-				"title": "Verify your email:",
-				"description": "Find the confirmation link."
-			}
-		},
-		"vote": {
-			"title": "Vote this video"
-		}
-	},
-	"myVideos": {
-		"title": "My videos",
-		"item": {
-			"status": {
-				"label": "Status",
-				"published": "Published",
-				"unpublished": "Unpublished"
-			}
-		}
-	},
-	"navigation": {
-		"voucher": "Get credits",
-		"myVideos": "Submit &  Edit",
-		"upload": "Upload",
-		"about": "About Paratii",
-		"logIn": "Be a contributor",
-		"profile": "Profile",
-		"telegram": "Join our Telegram"
-	},
-	"notFound": {
-		"title": "Houston, we have a problem.",
-		"description": "Landing procedure not completed. Either a wrong link, or the page is under construction. Help us telling how you got here:",
-		"linkText": "Paratii-Video"
-	},
-	"player": {
-		"free": "Free",
-		"views": {
-			"zero": "0"
-		},
-		"share": {
-			"title": "Share this video",
-			"options": {
-				"telegram": "Telegram",
-				"twitter": "Twitter",
-				"whatsapp": "WhatsApp",
-				"embed": "Embed"
-			},
-			"embedVideo": "Embed this video"
-		}
-	},
-	"PTI": "💎",
-	"invested": "🔐",
-	"profile": {
-		"title": "Profile",
-		"editButton": "Edit",
-		"dataLabel": "Since",
-		"balanceTitle": "Balance",
-		"investedTitle": "Invested ",
-		"emailLabel": "E-mail",
-		"addressLabel": "Address",
-		"copyLabel": "Copy"
-	},
-	"profileEdit": {
-		"title": "Edit Profile",
-		"avatarLabel": "Change avatar",
-		"usernameLabel": "Username",
-		"emailLabel": "E-mail",
-		"cancelButton": "Cancel",
-		"saveButton": "Save"
-	},
-	"profileLogOut": {
-		"title": "Profile",
-		"text": "You must login to see this content.",
-		"button": "Log in"
-	},
-	"ptiGuide": {
-		"title": "What are credits?",
-		"description": "Suggested reading before you upload any content.",
-		"callToAction": "Discover how to use your credits",
-		"ptiGuide": "Credits Guide",
-		"steps": {
-			"token": {
-				"mainContent": "PTI is the native token of the Paratii open system. We call it a \"system\" because the network executes operations with PTI although nobody \"owns\" the machinery who does the job.",
-				"subContent": "PTI tokens are issued, distributed and collected by smart contracts that live on the Ethereum blockchain. Every new registered user on Paratii earns some tokens to experiment with. They show up on the top right of this page (click that icon!) or in our embedded player, when one is watching through other sites. Let's see what you can do with PTI?"
-			},
-			"staking": {
-				"mainContent": "The basic operation here is staking. Whenever you upload a video, 5 of your tokens will be automatically \"attached to it\", as it enters the system. Think of it as a security deposit.",
-				"subContent": "At any time, you will be able to retrieve your tokens back, which also delists the video from this web portal and related interfaces. On the other hand, those who leave tokens staked are continuously granted rewards, issued through inflation, and can also earn profits if the playlists their videos belong to are performing well (these two functions are not live yet). So uploading content and staking are forms of active participation in this economy."
-			},
-			"flagging": {
-				"mainContent": "Videos will be subject to \"flags\". Flagging a video means matching its stake, by putting up an equivalent amount for challenge.",
-				"subContent": "Any user can then go in favour or disfavour that video’s presence on the system. Videos collectively rejected lose their stakes - forfeited PTI go to voters in the challenge (people who flagged or disapproved) and to all people actively staking tokens in the system, at the moment. That means that keeping a well curated record of videos - one that keeps attracting creators and spitting out harmful content - can be a profitable activity to the system's participants."
-			},
-			"conclusion": {
-				"mainContent": "Soon, PTI will also be usable for facilitating micro payments. Creators will have monetisation options to directly receive value from their audiences and/or advertisers.",
-				"subContent_html": "Most important for now is that you understand PTI as an entry ticket to take part in an economy that belongs to you as much as you are willing to belong to it. Tokens displayed here are in a test environment still, and have no monetary value. If you're willing to claim some extra test PTI, ask questions, or make suggestions about the token's feature set itself, don't hesitate to %{getInTouchEmailLink}.",
-				"getInTouch": "get in touch"
-			}
-		}
-	},
-	"uploadListItem": {
-		"statusMessage": {
-			"needsTitle": "Please provide a title and description.",
-			"videoReady": "✅ Your video is ready!",
-			"uploadFailed": "Your video could not be uploaded.",
-			"transcodeFailed": "Your video could not be transcoded.",
-			"transcoding": "Transcoding your video...",
-			"uploading": "Uploading your video..."
-		},
-		"title": "Title",
-		"description": "Description",
-		"ownership": "Who does this belong to?",
-		"videoId": "Video Id",
-		"contentType": {
-			"title": "What kind of content?",
-			"free": "Free",
-			"paid": "Paid"
-		},
-		"publish": "Publish",
-		"termsOfService_html": "By clicking \"Publish\", you agree to %{termsOfServiceLink}. Don't violate others’ copyright or privacy rights.",
-		"termsOfServiceLinkText": "Paratii’s Terms of Service",
-		"save": "Save",
-		"noVideo": "No video selected!",
-		"insufficientBalance": {
-			"title": "Not enough tokens",
-			"description": "You need at least %{amount} PTI to stake."
-		}
-	},
-	"search": {
-		"input": {
-			"placeholder": "Search"
-		},
-		"results": {
-			"resultsFor": "What's on store for \"%{term}\":",
-			"noResultsFor": "No results found for \"%{term}\"",
-			"moreResults": "See more results",
-			"zeroState": "Enter some keywords above to search.",
-			"relatedContent": "Related content",
-			"relatedContentCategories": "Categories:"
-		}
-	},
-	"tcr": {
-		"ChallengePeriod": {
-			"whitelistedTitle_html": "<strong>Voting period</strong> ends in",
-			"challengedTitle_html": "<strong>Challenge period</strong> ends in",
-			"inRevealTitle_html": "<strong>Time to reveal</strong> ends in",
-			"whitelistedLabel": "Whitelisted",
-			"challengedLabel": "Voting",
-			"inRevealLabel": "Reveal ",
-			"hourLabel": "hour",
-			"minutesLabel": "minutes",
-			"secondsLabel": "seconds"
-		},
-		"CommitYourVote": {
-			"title": "Choose your side",
-			"text": "Vote YAY or NAY to the permanence of this video in the platform.",
-			"buttonSupport": "Yay",
-			"buttonOppose": "Nay"
-		},
-		"RevealYourVote": {
-			"title": "You need to send back your vote!",
-			"text": "You need to send back your vote to reveal it. If you forget, your vote won't count.",
-			"button": "Reveal your vote"
-		},
-		"VideoApproved": {
-			"title": "This video has been approved",
-			"text": "The community supported the permanence of this video on the platform. It can be challenged again in 6 days."
-		},
-		"VideoRejected": {
-			"title": "This video has been rejected",
-			"text": "The community opposed the permanence of this video on the platform. The video was deleted after, probably because it broke one of our policies."
-		},
-		"VoteCommitted": {
-			"title": "Vote Committed",
-			"text_html": "Wait until the commit period ends, to reveal your vote. You will send it <strong>back</strong> when the reveal period starts. If you don’t send it back, your vote won't count."
-		},
-		"VoteRevealed": {
-			"title": "Vote Revealed",
-			"text": "Your vote has been revealed, now you just need to wait until the reveal period ends."
-		},
-		"Voting": {
-			"title": "Voting",
-			"box1Label": "Yay",
-			"box2Label": "Nay",
-			"dateLabel": "Date of the challenge:"
-		},
-		"WhiteListed": {
-			"title": "This video is ",
-			"text": "This video has been published to our network. If it breaks any of the rules, challenge it and compete for rewards.",
-			"button": "Challenge"
-		}
-	},
-	"tipping": {
-		"giveTip": "Give a tip",
-		"amounts": {
-			"10": "10",
-			"15": "15",
-			"20": "20",
-			"25": "25"
-		},
-		"defaultAuthor": "the author",
-		"tippingError": "Something went wrong with the tipping process",
-		"steps": {
-			"chooseAmount": {
-				"header": "Feeling generous today?",
-				"chooseTip": "Choose how much to tip %{username} :"
-			},
-			"enterPassword": {
-				"header": "You are about to tip",
-				"inputPlaceholder": "Password",
-				"continue": "Continue",
-				"wrongPassword": "Wrong password"
-			},
-			"completed": {
-				"header1": "%{username} appreciates that.",
-				"header2": "Thanks for making %{username}'s day happier.",
-				"header3": "Tips are like hugs. Without all the touching.",
-				"continueWatching": "Continue watching"
-			}
-		}
-	},
-	"uploader": {
-		"dragFiles": "Drag your files here",
-		"filesInstructions_html": "%{dragFiles} or click to find them",
-		"supportedFileTypes": "(only .mp4 currently supported)",
-		"youtubeOrVimeo": "(Not working yet) Or upload from Youtube or Vimeo",
-		"notifications": {
-			"starting": {
-				"title": "Be patient.",
-				"description": "Preparing your file for the journey."
-			},
-			"uploadError": {
-				"title": "❌ Upload error:",
-				"description": "Something went wrong with your file. Please retry."
-			},
-			"uploaded": {
-				"title": "File uploaded:",
-				"description": "Your pixels are now being transcoded."
-			},
-			"transcodeError": {
-				"title": "❌ Transcoding error:",
-				"description": "Machines are not cooperating. Please refresh, sir?"
-			},
-			"transcoding": {
-				"title": "Transcoding:",
-				"description": "The transcoding party has started."
-			},
-			"transcoded": {
-				"title": "Transcoding done:",
-				"description": "✅ Video ready to be published!"
-			},
-			"saving": {
-				"title": "We are saving your data."
-			},
-			"saved": {
-				"title": "Saved",
-				"description": "Data saved!"
-			},
-			"saveError": {
-				"title": "❌ Saving error."
-			}
-		}
-	},
-	"userNav": {
-		"dataLabel": "Since",
-		"leftBoxTitle": "Available",
-		"rightBoxTitle": "Staked"
-	},
-	"videoNotFound": {
-		"title": "Houston, we have a problem.",
-		"description": "Landing procedure not completed. This video does not exist. Help us, telling how you got here:",
-		"linkText": "Paratii-Video"
-	},
-	"wallet": {
-		"securingWallet": "Crafting you an account...",
-		"walletSecured": "You have a secure account!",
-		"unlockingKeystore": "Unlocking your wallet...",
-		"enterPassword": {
-			"title": "Enter your password",
-			"description": "Log in to access all features of the Lab.",
-			"inputPlaceholder": "My password",
-			"forgotPassword": "Forgot Password",
-			"continue": "Continue",
-			"success": {
-				"title": "✅ Success!",
-				"description": "Your wallet is ready to go."
-			},
-			"error": {
-				"title": "Password invalid",
-				"description": "Please reypte the password.",
-				"formErrorMessage": "Wrong password, please retry."
-			}
-		},
-		"restoreAccount": {
-			"title": "Remember that string of words we asked you to save?",
-			"description": "Enter your account key (those 12 words you copied) to continue.",
-			"mnemonic": "Account key (12 words)",
-			"continue": "Continue",
-			"goBack": "Forgot it. Make me a new account",
-			"errorMessage": "The 12 words you entered are not valid."
-		},
-		"secureAccount": {
-			"title": "Ready to sign up?",
-			"description": "It only takes 3 steps.",
-			"alreadyHaveAccount": "Access existing account",
-			"secureThisAccount": "Make new account"
-		},
-		"choosePassword": {
-			"title": "Create a password.",
-			"description_html": "Make it 8 characters or longer. Include at least 1 uppercase letter and 1 number.",
-			"newPasswordLabel": "Password",
-			"confirmPasswordLabel": "Confirm Password",
-			"continue": "Continue",
-			"back": "Go back",
-			"errors": {
-				"passwordMismatch": "Machine. Is. Confused. Passwords don't match.",
-				"eightCharacters": "Password must be 8 characters or longer.",
-				"numericCharacter": "Password must contain at least 1 number.",
-				"uppercaseCharacter": "Password must contain at least 1 uppercase letter."
-			}
-		},
-		"showSeed": {
-			"title": "🔑 Voilá: here's your account key.",
-			"description_html": "This is the only proof that you own this account. %{keepSafe}",
-			"keepSafe": "Keep it secret. Keep it safe",
-			"copy": {
-				"buttonText": "Copy",
-				"confirmCopy": "I have copied the 12 words. They are secret, safe and sound.",
-				"notification": {
-					"title": "Copied!",
-					"description": "Your account key has been copied to the clipboard."
-				}
-			},
-			"goBack": "Go back",
-			"continue": "Continue"
-		}
-	}
+  "footer": {
+    "discover_html": "Learn more about Paratii at %{homePageLink}",
+    "homePage": "paratii.video",
+    "betaTool_html": "v0.0.2: This is an alpha tool! We &hearts; to get feedback on Telegram: %{telegramBrazilLink} or %{telegramEnglishLink}",
+    "brazil": "Portuguese",
+    "english": "English"
+  },
+  "landingPage": {
+    "alert_html": "<strong>Alpha product</strong> (on an Ethereum testnet). Code hasn’t been audited. Don’t share sensitive information.",
+    "header": {
+      "title_html": "🎉 Around the block:<br /> Episode 2 is live",
+      "description_html": "A 4-part docuseries on the story of crypto-land.<br /> 👇 Start watching now!",
+      "button": "Ep."
+    },
+    "text": "Lab is a peer-to-peer video site that doesn't spy on you. Find series, tutorials, speeches and discover crypto-communities beyond your own.",
+    "button": "+ Discover more",
+    "videos": {
+      "title": "Meet your fellow pioneers",
+      "description": "Explore short stories, music clips, and formats that our community is inventing every day."
+    }
+  },
+  "modal": {
+    "challenge": {
+      "title": "Challenge this video"
+    },
+    "profile": {
+      "title": "Profile",
+      "description": "This is how you'll be known. Enter your email to receive updates about the community and your activity.",
+      "usernameLabel": "Username",
+      "emailLabel": "Email",
+      "continue": "Continue",
+      "pleaseWait": "Please wait: creating your wallet.",
+      "verificationEmail": {
+        "title": "Verify your email:",
+        "description": "Find the confirmation link."
+      }
+    },
+    "vote": {
+      "title": "Vote this video"
+    }
+  },
+  "myVideos": {
+    "title": "My videos",
+    "item": {
+      "status": {
+        "label": "Status",
+        "published": "Published",
+        "unpublished": "Unpublished"
+      }
+    }
+  },
+  "navigation": {
+    "voucher": "Get credits",
+    "myVideos": "Submit &  Edit",
+    "upload": "Upload",
+    "about": "About Paratii",
+    "logIn": "Be a contributor",
+    "profile": "Profile",
+    "telegram": "Join our Telegram"
+  },
+  "notFound": {
+    "title": "Houston, we have a problem.",
+    "description": "Landing procedure not completed. Either a wrong link, or the page is under construction. Help us telling how you got here:",
+    "linkText": "Paratii-Video"
+  },
+  "player": {
+    "free": "Free",
+    "views": {
+      "zero": "0"
+    },
+    "share": {
+      "title": "Share this video",
+      "options": {
+        "telegram": "Telegram",
+        "twitter": "Twitter",
+        "whatsapp": "WhatsApp",
+        "embed": "Embed"
+      },
+      "embedVideo": "Embed this video"
+    }
+  },
+  "PTI": "💎",
+  "invested": "🔐",
+  "profile": {
+    "title": "Profile",
+    "editButton": "Edit",
+    "dataLabel": "Since",
+    "balanceTitle": "Balance",
+    "investedTitle": "Invested ",
+    "emailLabel": "E-mail",
+    "addressLabel": "Address",
+    "copyLabel": "Copy"
+  },
+  "profileEdit": {
+    "title": "Edit Profile",
+    "avatarLabel": "Change avatar",
+    "usernameLabel": "Username",
+    "emailLabel": "E-mail",
+    "cancelButton": "Cancel",
+    "saveButton": "Save"
+  },
+  "profileLogOut": {
+    "title": "Profile",
+    "text": "You must login to see this content.",
+    "button": "Log in"
+  },
+  "ptiGuide": {
+    "title": "What are credits?",
+    "description": "Suggested reading before you upload any content.",
+    "callToAction": "Discover how to use your credits",
+    "ptiGuide": "Credits Guide",
+    "steps": {
+      "token": {
+        "mainContent": "PTI is the native token of the Paratii open system. We call it a \"system\" because the network executes operations with PTI although nobody \"owns\" the machinery who does the job.",
+        "subContent": "PTI tokens are issued, distributed and collected by smart contracts that live on the Ethereum blockchain. Every new registered user on Paratii earns some tokens to experiment with. They show up on the top right of this page (click that icon!) or in our embedded player, when one is watching through other sites. Let's see what you can do with PTI?"
+      },
+      "staking": {
+        "mainContent": "The basic operation here is staking. Whenever you upload a video, 5 of your tokens will be automatically \"attached to it\", as it enters the system. Think of it as a security deposit.",
+        "subContent": "At any time, you will be able to retrieve your tokens back, which also delists the video from this web portal and related interfaces. On the other hand, those who leave tokens staked are continuously granted rewards, issued through inflation, and can also earn profits if the playlists their videos belong to are performing well (these two functions are not live yet). So uploading content and staking are forms of active participation in this economy."
+      },
+      "flagging": {
+        "mainContent": "Videos will be subject to \"flags\". Flagging a video means matching its stake, by putting up an equivalent amount for challenge.",
+        "subContent": "Any user can then go in favour or disfavour that video’s presence on the system. Videos collectively rejected lose their stakes - forfeited PTI go to voters in the challenge (people who flagged or disapproved) and to all people actively staking tokens in the system, at the moment. That means that keeping a well curated record of videos - one that keeps attracting creators and spitting out harmful content - can be a profitable activity to the system's participants."
+      },
+      "conclusion": {
+        "mainContent": "Soon, PTI will also be usable for facilitating micro payments. Creators will have monetisation options to directly receive value from their audiences and/or advertisers.",
+        "subContent_html": "Most important for now is that you understand PTI as an entry ticket to take part in an economy that belongs to you as much as you are willing to belong to it. Tokens displayed here are in a test environment still, and have no monetary value. If you're willing to claim some extra test PTI, ask questions, or make suggestions about the token's feature set itself, don't hesitate to %{getInTouchEmailLink}.",
+        "getInTouch": "get in touch"
+      }
+    }
+  },
+  "uploadListItem": {
+    "statusMessage": {
+      "needsTitle": "Please provide a title and description.",
+      "videoReady": "✅ Your video is ready!",
+      "uploadFailed": "Your video could not be uploaded.",
+      "transcodeFailed": "Your video could not be transcoded.",
+      "transcoding": "Transcoding your video...",
+      "uploading": "Uploading your video..."
+    },
+    "title": "Title",
+    "description": "Description",
+    "ownership": "Who does this belong to?",
+    "videoId": "Video Id",
+    "contentType": {
+      "title": "What kind of content?",
+      "free": "Free",
+      "paid": "Paid"
+    },
+    "publish": "Publish",
+    "termsOfService_html": "By clicking \"Publish\", you agree to %{termsOfServiceLink}. Don't violate others’ copyright or privacy rights.",
+    "termsOfServiceLinkText": "Paratii’s Terms of Service",
+    "save": "Save",
+    "noVideo": "No video selected!",
+    "insufficientBalance": {
+      "title": "Not enough tokens",
+      "description": "You need at least %{amount} PTI to stake."
+    }
+  },
+  "search": {
+    "input": {
+      "placeholder": "Search"
+    },
+    "results": {
+      "resultsFor": "What's on store for \"%{term}\":",
+      "noResultsFor": "No results found for \"%{term}\"",
+      "moreResults": "See more results",
+      "zeroState": "Enter some keywords above to search.",
+      "relatedContent": "Related content",
+      "relatedContentCategories": "Categories:"
+    }
+  },
+  "tcr": {
+    "ChallengePeriod": {
+      "whitelistedTitle_html": "<strong>Voting period</strong> ends in",
+      "challengedTitle_html": "<strong>Challenge period</strong> ends in",
+      "inRevealTitle_html": "<strong>Time to reveal</strong> ends in",
+      "whitelistedLabel": "Whitelisted",
+      "challengedLabel": "Voting",
+      "inRevealLabel": "Reveal ",
+      "hourLabel": "hour",
+      "minutesLabel": "minutes",
+      "secondsLabel": "seconds"
+    },
+    "CommitYourVote": {
+      "title": "Choose your side",
+      "text": "Vote YAY or NAY to the permanence of this video in the platform.",
+      "buttonSupport": "Yay",
+      "buttonOppose": "Nay"
+    },
+    "RevealYourVote": {
+      "title": "You need to send back your vote!",
+      "text": "You need to send back your vote to reveal it. If you forget, your vote won't count.",
+      "button": "Reveal your vote"
+    },
+    "VideoApproved": {
+      "title": "This video has been approved",
+      "text": "The community supported the permanence of this video on the platform. It can be challenged again in 6 days."
+    },
+    "VideoRejected": {
+      "title": "This video has been rejected",
+      "text": "The community opposed the permanence of this video on the platform. The video was deleted after, probably because it broke one of our policies."
+    },
+    "VoteCommitted": {
+      "title": "Vote Committed",
+      "text_html": "Wait until the commit period ends, to reveal your vote. You will send it <strong>back</strong> when the reveal period starts. If you don’t send it back, your vote won't count."
+    },
+    "VoteRevealed": {
+      "title": "Vote Revealed",
+      "text": "Your vote has been revealed, now you just need to wait until the reveal period ends."
+    },
+    "Voting": {
+      "title": "Voting",
+      "box1Label": "Yay",
+      "box2Label": "Nay",
+      "dateLabel": "Date of the challenge:"
+    },
+    "WhiteListed": {
+      "title": "This video is ",
+      "text": "This video has been published to our network. If it breaks any of the rules, challenge it and compete for rewards.",
+      "button": "Challenge"
+    }
+  },
+  "tipping": {
+    "giveTip": "Give a tip",
+    "amounts": {
+      "10": "10",
+      "15": "15",
+      "20": "20",
+      "25": "25"
+    },
+    "defaultAuthor": "the author",
+    "tippingError": "Something went wrong with the tipping process",
+    "steps": {
+      "chooseAmount": {
+        "header": "Feeling generous today?",
+        "chooseTip": "Choose how much to tip %{username} :"
+      },
+      "enterPassword": {
+        "header": "You are about to tip",
+        "inputPlaceholder": "Password",
+        "continue": "Continue",
+        "wrongPassword": "Wrong password"
+      },
+      "completed": {
+        "header1": "%{username} appreciates that.",
+        "header2": "Thanks for making %{username}'s day happier.",
+        "header3": "Tips are like hugs. Without all the touching.",
+        "continueWatching": "Continue watching"
+      }
+    }
+  },
+  "uploader": {
+    "dragFiles": "Drag your files here",
+    "filesInstructions_html": "%{dragFiles} or click to find them",
+    "supportedFileTypes": "(only .mp4 <2gb currently supported)",
+    "youtubeOrVimeo": "(Not working yet) Or upload from Youtube or Vimeo",
+    "notifications": {
+      "starting": {
+        "title": "Be patient.",
+        "description": "Preparing your file for the journey."
+      },
+      "uploadError": {
+        "title": "❌ Upload error:",
+        "description": "Something went wrong with your file. Please retry."
+      },
+      "uploaded": {
+        "title": "File uploaded:",
+        "description": "Your pixels are now being transcoded."
+      },
+      "transcodeError": {
+        "title": "❌ Transcoding error:",
+        "description": "Machines are not cooperating. Please refresh, sir?"
+      },
+      "transcoding": {
+        "title": "Transcoding:",
+        "description": "The transcoding party has started."
+      },
+      "transcoded": {
+        "title": "Transcoding done:",
+        "description": "✅ Video ready to be published!"
+      },
+      "saving": {
+        "title": "We are saving your data."
+      },
+      "saved": {
+        "title": "Saved",
+        "description": "Data saved!"
+      },
+      "saveError": {
+        "title": "❌ Saving error."
+      },
+      "fileError": {
+        "title": "❌ Invalid file:",
+        "description": "Unsupported file format. Please use .mp4 files under 2GB."
+      }
+    }
+  },
+  "userNav": {
+    "dataLabel": "Since",
+    "leftBoxTitle": "Available",
+    "rightBoxTitle": "Staked"
+  },
+  "videoNotFound": {
+    "title": "Houston, we have a problem.",
+    "description": "Landing procedure not completed. This video does not exist. Help us, telling how you got here:",
+    "linkText": "Paratii-Video"
+  },
+  "wallet": {
+    "securingWallet": "Crafting you an account...",
+    "walletSecured": "You have a secure account!",
+    "unlockingKeystore": "Unlocking your wallet...",
+    "enterPassword": {
+      "title": "Enter your password",
+      "description": "Log in to access all features of the Lab.",
+      "inputPlaceholder": "My password",
+      "forgotPassword": "Forgot Password",
+      "continue": "Continue",
+      "success": {
+        "title": "✅ Success!",
+        "description": "Your wallet is ready to go."
+      },
+      "error": {
+        "title": "Password invalid",
+        "description": "Please reypte the password.",
+        "formErrorMessage": "Wrong password, please retry."
+      }
+    },
+    "restoreAccount": {
+      "title": "Remember that string of words we asked you to save?",
+      "description": "Enter your account key (those 12 words you copied) to continue.",
+      "mnemonic": "Account key (12 words)",
+      "continue": "Continue",
+      "goBack": "Forgot it. Make me a new account",
+      "errorMessage": "The 12 words you entered are not valid."
+    },
+    "secureAccount": {
+      "title": "Ready to sign up?",
+      "description": "It only takes 3 steps.",
+      "alreadyHaveAccount": "Access existing account",
+      "secureThisAccount": "Make new account"
+    },
+    "choosePassword": {
+      "title": "Create a password.",
+      "description_html": "Make it 8 characters or longer. Include at least 1 uppercase letter and 1 number.",
+      "newPasswordLabel": "Password",
+      "confirmPasswordLabel": "Confirm Password",
+      "continue": "Continue",
+      "back": "Go back",
+      "errors": {
+        "passwordMismatch": "Machine. Is. Confused. Passwords don't match.",
+        "eightCharacters": "Password must be 8 characters or longer.",
+        "numericCharacter": "Password must contain at least 1 number.",
+        "uppercaseCharacter": "Password must contain at least 1 uppercase letter."
+      }
+    },
+    "showSeed": {
+      "title": "🔑 Voilá: here's your account key.",
+      "description_html": "This is the only proof that you own this account. %{keepSafe}",
+      "keepSafe": "Keep it secret. Keep it safe",
+      "copy": {
+        "buttonText": "Copy",
+        "confirmCopy": "I have copied the 12 words. They are secret, safe and sound.",
+        "notification": {
+          "title": "Copied!",
+          "description": "Your account key has been copied to the clipboard."
+        }
+      },
+      "goBack": "Go back",
+      "continue": "Continue"
+    }
+  }
 }

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -1,369 +1,373 @@
 {
-	"footer": {
-		"discover_html": "Saiba mais sobre a Paratii em %{homePageLink}",
-		"homePage": "paratii.video",
-		"betaTool_html": "v0.0.2: Este portal está em desenvolvimento! Nós &hearts; ouvir seu feedback no Telegram: %{telegramBrazilLink} ou %{telegramEnglishLink}.",
-		"brazil": "Portuguese",
-		"english": "English"
-	},
-	"landingPage": {
-		"alert_html": "<strong>Esté é um Alpha</strong> (numa testnet da Ethereum). O código não foi auditado. Não compartilhe informações sensíveis.",
-		"header": {
-			"title_html": "🎉 Around the block:<br />: 1º episódio lançado",
-			"description_html": "Uma websérie documental sobre as mentes por trás<br /> da descentralização. Assista agora! 👇",
-			"button": "Ep."
-		},
-		"text": "O Lab é uma plataforma peer-to-peer que não espia nem revende suas informações. Encontre séries, tutoriais, palestras e descubra as cripto-comunidades que existem além da sua.",
-		"button": "+ Veja mais",
-		"videos": {
-			"title": "Meet your fellow pioneers",
-			"description": "Explore short stories, music clips, and formats that our community is inventing every day."
-		}
-	},
-	"modal": {
-		"challenge": {
-			"title": "Desafie este vídeo"
-		},
-		"profile": {
-			"title": "Perfil",
-			"description": "Como você quer ser conhecido? Insira seu email para receber updates sobre a comunidade e sua atividade.",
-			"usernameLabel": "Nome de usuário",
-			"emailLabel": "Email",
-			"continue": "Continuar",
-			"pleaseWait": "Aguarde: criando conta.",
-			"verificationEmail": {
-				"title": "Verifique seu email:",
-				"description": "Encontre o link de confirmação."
-			}
-		},
-		"vote": {
-			"title": "Vote neste vídeo."
-		}
-	},
-	"myVideos": {
-		"title": "Meus vídeos",
-		"item": {
-			"status": {
-				"label": "Status",
-				"published": "Publicado",
-				"unpublished": "Não-publicado"
-			}
-		}
-	},
-	"navigation": {
-		"voucher": " Tokens",
-		"myVideos": "Enviar & editar",
-		"upload": "Upload",
-		"about": "Sobre a Paratii",
-		"logIn": "Login",
-		"profile": "Perfil",
-		"telegram": "Entre no Telegram"
-	},
-	"notFound": {
-		"title": "Houston, temos um problema.",
-		"description": "Pouso não completado. Causa: link errado, ou a página está em construção. Se quiser ajudar, nos conta como chegou aqui:",
-		"linkText": "Paratii-Video"
-	},
-	"player": {
-		"free": "Gratuito",
-		"views": {
-			"zero": "0"
-		},
-		"share": {
-			"title": "Compartilhar",
-			"options": {
-				"telegram": "Telegram",
-				"twitter": "Twitter",
-				"whatsapp": "WhatsApp",
-				"embed": "Embed"
-			},
-			"embedVideo": "Embedar vídeo"
-		}
-	},
-	"PTI": "💎",
-	"invested": "🔐",
-	"profile": {
-		"title": "Perfil",
-		"editButton": "Editar",
-		"dataLabel": "Desde",
-		"balanceTitle": "Saldo",
-		"investedTitle": "Investido",
-		"emailLabel": "E-mail",
-		"addressLabel": "Endereço",
-		"copyLabel": "Copiar"
-	},
-	"profileEdit": {
-		"title": "Editar perfil",
-		"avatarLabel": "Editar avatar",
-		"usernameLabel": "Nome de usuário",
-		"emailLabel": "E-mail",
-		"cancelButton": "Cancelar",
-		"saveButton": "Salvar"
-	},
-	"profileLogOut": {
-		"title": "Perfil",
-		"text": "Você deve estar logado para acessar este conteúdo.",
-		"button": "Login"
-	},
-	"ptiGuide": {
-		"title": "O que são tokens?",
-		"description": "Leitura recomendada antes de submeter vídeos",
-		"callToAction": "Descubra como usar seus créditos",
-		"ptiGuide": "Credits Guide",
-		"steps": {
-			"token": {
-				"mainContent": "PTI is the native token of the Paratii open system. We call it a \"system\" because the network executes operations with PTI although nobody \"owns\" the machinery who does the job.",
-				"subContent": "PTI tokens are issued, distributed and collected by smart contracts that live on the Ethereum blockchain. Every new registered user on Paratii earns some tokens to experiment with. They show up on the top right of this page (click that icon!) or in our embedded player, when one is watching through other sites. Let's see what you can do with PTI?"
-			},
-			"staking": {
-				"mainContent": "The basic operation here is staking. Whenever you upload a video, 5 of your tokens will be automatically \"attached to it\", as it enters the system. Think of it as a security deposit.",
-				"subContent": "At any time, you will be able to retrieve your tokens back, which also delists the video from this web portal and related interfaces. On the other hand, those who leave tokens staked are continuously granted rewards, issued through inflation, and can also earn profits if the playlists their videos belong to are performing well (these two functions are not live yet). So uploading content and staking are forms of active participation in this economy."
-			},
-			"flagging": {
-				"mainContent": "Videos will be subject to \"flags\". Flagging a video means matching its stake, by putting up an equivalent amount for challenge.",
-				"subContent": "Any user can then go in favour or disfavour that video’s presence on the system. Videos collectively rejected lose their stakes - forfeited PTI go to voters in the challenge (people who flagged or disapproved) and to all people actively staking tokens in the system, at the moment. That means that keeping a well curated record of videos - one that keeps attracting creators and spitting out harmful content - can be a profitable activity to the system's participants."
-			},
-			"conclusion": {
-				"mainContent": "Soon, PTI will also be usable for facilitating micro payments. Creators will have monetisation options to directly receive value from their audiences and/or advertisers.",
-				"subContent_html": "Most important for now is that you understand PTI as an entry ticket to take part in an economy that belongs to you as much as you are willing to belong to it. Tokens displayed here are in a test environment still, and have no monetary value. If you're willing to claim some extra test PTI, ask questions, or make suggestions about the token's feature set itself, don't hesitate to %{getInTouchEmailLink}.",
-				"getInTouch": "get in touch"
-			}
-		}
-	},
-	"uploadListItem": {
-		"statusMessage": {
-			"needsTitle": "Escreva um título e uma descrição.",
-			"videoReady": "✅ Vídeo pronto!",
-			"uploadFailed": "O upload do seu vídeo falhou.",
-			"transcodeFailed": "Seu vídeo falhou em ser transcodado.",
-			"transcoding": "Transcodando seu vídeo...",
-			"uploading": "Fazendo upload do vídeo..."
-		},
-		"title": "Título",
-		"description": "Descrição",
-		"ownership": "A quem os direitos deste vídeo pertencem? Por favor, aponte um link que comprove.",
-		"videoId": "Video Id",
-		"contentType": {
-			"title": "Que tipo de conteúdo?",
-			"free": "Gratuito",
-			"paid": "Pago (não disponível)"
-		},
-		"publish": "Publicar",
-		"termsOfService": "Ao \"Publicar\", você concorda com os Termos de Uso da Paratii. Não são permitidas violações de direito ou privacidade.",
-		"save": "Salvar",
-		"noVideo": "Nenhum vídeo selecionado!",
-		"insufficientBalance": {
-			"title": "Sem créditos suficientes",
-			"description": "Você precisa de %{amount} créditos para realizar esta ação."
-		}
-	},
-	"search": {
-		"input": {
-			"placeholder": "Buscar"
-		},
-		"results": {
-			"resultsFor": "O que encontramos sobre \"%{term}\":",
-			"noResultsFor": "Nenhum resultado para \"%{term}\"",
-			"moreResults": "Veja mais resultados",
-			"zeroState": "Escreva algumas palavras-chave acima para fazer uma busca.",
-			"relatedContent": "Conteúdo relacionado",
-			"relatedContentCategories": "Categorias:"
-		}
-	},
-	"tcr": {
-		"ChallengePeriod": {
-			"whitelistedTitle_html": "<strong>Período de votação</strong> acaba em",
-			"challengedTitle_html": "<strong>Período de desafio</strong> acaba em",
-			"inRevealTitle_html": "<strong>Período de relevação</strong> acaba em",
-			"whitelistedLabel": "Aprovados",
-			"challengedLabel": "Em votação",
-			"inRevealLabel": "Em revelação",
-			"hourLabel": "hora",
-			"minutesLabel": "minutos",
-			"secondsLabel": "segundos"
-		},
-		"CommitYourVote": {
-			"title": "Escolha um lado",
-			"text": "Vote YAY ou NAY sobre a permanência ou não deste vídeo na plataforma.",
-			"buttonSupport": "Yay",
-			"buttonOppose": "Nay"
-		},
-		"RevealYourVote": {
-			"title": "Você precisará revelar o seu voto mais tarde!",
-			"text": "Se você esquecer de fazê-lo, seu voto não contará, mas não perderá seus créditos.",
-			"button": "Revelar voto"
-		},
-		"VideoApproved": {
-			"title": "Este vídeo foi aprovado.",
-			"text": "A comunidade escolheu YAY. Este vídeo pode ser desafiado de novo em 6 dias."
-		},
-		"VideoRejected": {
-			"title": "Este vídeo foi rejeitado.",
-			"text": "A comunidade escolheu NAY. Este vídeo foi delistado, provavelmente por violar os termos de uso da plataforma."
-		},
-		"VoteCommitted": {
-			"title": "Voto comprometido",
-			"text_html": "Quando o período de comprometimento acabar, volte para revelar seu voto. Você deverá enviá-lo <strong>back</strong> durante o período de revelação. Se não revelá-lo, seu voto não contará."
-		},
-		"VoteRevealed": {
-			"title": "Voto revelado",
-			"text": "Seu voto foi revelado. Agora é só esperar o fim do período de revelação para sabermos o resultado."
-		},
-		"Voting": {
-			"title": "Votar",
-			"box1Label": "Yay",
-			"box2Label": "Nay",
-			"dateLabel": "Data do desafio:"
-		},
-		"WhiteListed": {
-			"title": "Este vídeo está ",
-			"text": "Este vídeo fo publicado na rede. Se estiver violando nossos termos de uso, desafie ele para competir por recompensas.",
-			"button": "Desafiar"
-		}
-	},
-	"tipping": {
-		"giveTip": "Fazer doação",
-		"amounts": {
-			"10": "10",
-			"15": "15",
-			"20": "20",
-			"25": "25"
-		},
-		"defaultAuthor": "o autor",
-		"tippingError": "Algo deu errado com o envio.",
-		"steps": {
-			"chooseAmount": {
-				"header": "Sentindo-se generoso?",
-				"chooseTip": "Escolha quanto quer doar a %{username} :"
-			},
-			"enterPassword": {
-				"header": "Confirmando doação",
-				"inputPlaceholder": "Senha",
-				"continue": "Continuar",
-				"wrongPassword": "Senha incorreta"
-			},
-			"completed": {
-				"header1": "%{username} agradece.",
-				"header2": "Valeu por fazer o dia de %{username} mais feliz.",
-				"header3": "Doações são como abraços. Sem todo o contato físico.",
-				"continueWatching": "Continuar assistindo"
-			}
-		}
-	},
-	"uploader": {
-		"dragFiles": "Arraste arquivos aqui",
-		"filesInstructions_html": "%{dragFiles} ou clique para buscá-los na sua máquina",
-		"supportedFileTypes": "(somente .mp4 suportado)",
-		"youtubeOrVimeo": "(Não-funcional) Ou faça upload a partir do YouTube / Vimeo",
-		"notifications": {
-			"starting": {
-				"title": "Aguarde...",
-				"description": "Preparando seu arquivo para a jornada."
-			},
-			"uploadError": {
-				"title": "Erro de upload:",
-				"description": "Algo deu errado com o upload do arquivo. Tente novamente."
-			},
-			"uploaded": {
-				"title": "Upload completo:",
-				"description": "Seus pixels agora estão sendo transcodados."
-			},
-			"transcodeError": {
-				"title": "Erro de transcoding:",
-				"description": "As máquinas não estão cooperando. Pode recarregar a página?"
-			},
-			"transcoding": {
-				"title": "Transcodando:",
-				"description": "Aquele processo com nome estranho: soa como se estivessem mastigando seu vídeo."
-			},
-			"transcoded": {
-				"title": "Transcoding finalizado:",
-				"description": "✅ Vídeo pronto para ser publicado!"
-			},
-			"saving": {
-				"title": "Salvando dados..."
-			},
-			"saved": {
-				"title": "Salvo",
-				"description": "Dados salvos!"
-			},
-			"saveError": {
-				"title": "❌ Erro em salvar dados."
-			}
-		}
-	},
-	"userNav": {
-		"dataLabel": "Desde",
-		"leftBoxTitle": "Disponível",
-		"rightBoxTitle": "Investido"
-	},
-	"videoNotFound": {
-		"title": "Houston, temos um problema.",
-		"description": "Pouso não completado. Vídeo não existente, ou link errado. Se quiser ajudar, nos conta como chegou aqui:",
-		"linkText": "Paratii-Video"
-	},
-	"wallet": {
-        "securingWallet": "Criando uma conta...",
-        "walletSecured": "Você tem uma conta!",
-        "unlockingKeystore": "Acessando a carteira da sua conta...",
-        "enterPassword": {
-            "title": "Insira sua senha",
-            "description": "Favor inserir a sua senha para utilizar todos os recursos do Lab.",
-            "inputPlaceholder": "Insira sua senha",
-            "forgotPassword": "Esqueci minha senha",
-            "continue": "Continuar",
-            "success": {
-                "title": "✅ Sucesso!",
-                "description": "Sua conta está pronta para uso."
-            },
-            "error": {
-                "title": "A senha não está correta.",
-                "description": "Por favor escreve sua senha novamente.",
-                "formErrorMessage": "A senha não é válida, favor reescrevê-la."
-            }
-        },
-        "restoreAccount": {
-            "title": "Lembra daquelas 12 palavras que te pedimos pra guardar?",
-            "description": "Reescreva as 12 palavras (chave da conta) para continuar o processo.",
-            "mnemonic": "Chave da conta (12 palavras)",
-            "continue": "Continuar",
-            "goBack": "Voltar",
-            "errorMessage": "As 12 palavras inseridas não são válidas."
-        },
-		"secureAccount": {
-			"title": "Pronto para fazer uma conta?",
-			"description": "São só 3 passos.",
-			"alreadyHaveAccount": "Já tenho uma conta",
-			"secureThisAccount": "Criar nova conta"
-		},
-		"choosePassword": {
-			"title": "Crie uma senha.",
-			"description_html": "Use 89 caracteres ou mais. Inclua ao menos 1 letra maiúscula e 1 número.",
-			"newPasswordLabel": "Senha",
-			"confirmPasswordLabel": "Confirmar senha",
-			"continue": "Continuar",
-			"back": "Voltar",
-			"errors": {
-				"passwordMismatch": "Máquina. Está. Confusa. As senhas não batem!",
-				"eightCharacters": "Por favor, use 8 caracteres ou mais.",
-				"numericCharacter": "A senha deve ter ao menos 1 número.",
-				"uppercaseCharacter": "A senha deve ter ao menos 1 letra maiúscula."
-			}
-		},
-		"showSeed": {
-			"title": "🔑 Voilá: aqui está a chave da sua conta.",
-			"description_html": "Está é a única prova de que você é o dono dessa conta. %{keepSafe}",
-			"keepSafe": "Guarde-a em um lugar seguro. Mantenha a chave secreta.",
-			"copy": {
-				"buttonText": "Copiar",
-				"confirmCopy": "Já copiei as 12 palavras. Elas estão seguras e protegidas.",
-				"notification": {
-					"title": "Copiado!",
-					"description": "A chave da sua conta foi copiada para o clipboard."
-				}
-			},
-			"goBack": "Voltar",
-			"continue": "Continuar"
-		}
-	}
+  "footer": {
+    "discover_html": "Saiba mais sobre a Paratii em %{homePageLink}",
+    "homePage": "paratii.video",
+    "betaTool_html": "v0.0.2: Este portal está em desenvolvimento! Nós &hearts; ouvir seu feedback no Telegram: %{telegramBrazilLink} ou %{telegramEnglishLink}.",
+    "brazil": "Portuguese",
+    "english": "English"
+  },
+  "landingPage": {
+    "alert_html": "<strong>Esté é um Alpha</strong> (numa testnet da Ethereum). O código não foi auditado. Não compartilhe informações sensíveis.",
+    "header": {
+      "title_html": "🎉 Around the block:<br />: 1º episódio lançado",
+      "description_html": "Uma websérie documental sobre as mentes por trás<br /> da descentralização. Assista agora! 👇",
+      "button": "Ep."
+    },
+    "text": "O Lab é uma plataforma peer-to-peer que não espia nem revende suas informações. Encontre séries, tutoriais, palestras e descubra as cripto-comunidades que existem além da sua.",
+    "button": "+ Veja mais",
+    "videos": {
+      "title": "Meet your fellow pioneers",
+      "description": "Explore short stories, music clips, and formats that our community is inventing every day."
+    }
+  },
+  "modal": {
+    "challenge": {
+      "title": "Desafie este vídeo"
+    },
+    "profile": {
+      "title": "Perfil",
+      "description": "Como você quer ser conhecido? Insira seu email para receber updates sobre a comunidade e sua atividade.",
+      "usernameLabel": "Nome de usuário",
+      "emailLabel": "Email",
+      "continue": "Continuar",
+      "pleaseWait": "Aguarde: criando conta.",
+      "verificationEmail": {
+        "title": "Verifique seu email:",
+        "description": "Encontre o link de confirmação."
+      }
+    },
+    "vote": {
+      "title": "Vote neste vídeo."
+    }
+  },
+  "myVideos": {
+    "title": "Meus vídeos",
+    "item": {
+      "status": {
+        "label": "Status",
+        "published": "Publicado",
+        "unpublished": "Não-publicado"
+      }
+    }
+  },
+  "navigation": {
+    "voucher": " Tokens",
+    "myVideos": "Enviar & editar",
+    "upload": "Upload",
+    "about": "Sobre a Paratii",
+    "logIn": "Login",
+    "profile": "Perfil",
+    "telegram": "Entre no Telegram"
+  },
+  "notFound": {
+    "title": "Houston, temos um problema.",
+    "description": "Pouso não completado. Causa: link errado, ou a página está em construção. Se quiser ajudar, nos conta como chegou aqui:",
+    "linkText": "Paratii-Video"
+  },
+  "player": {
+    "free": "Gratuito",
+    "views": {
+      "zero": "0"
+    },
+    "share": {
+      "title": "Compartilhar",
+      "options": {
+        "telegram": "Telegram",
+        "twitter": "Twitter",
+        "whatsapp": "WhatsApp",
+        "embed": "Embed"
+      },
+      "embedVideo": "Embedar vídeo"
+    }
+  },
+  "PTI": "💎",
+  "invested": "🔐",
+  "profile": {
+    "title": "Perfil",
+    "editButton": "Editar",
+    "dataLabel": "Desde",
+    "balanceTitle": "Saldo",
+    "investedTitle": "Investido",
+    "emailLabel": "E-mail",
+    "addressLabel": "Endereço",
+    "copyLabel": "Copiar"
+  },
+  "profileEdit": {
+    "title": "Editar perfil",
+    "avatarLabel": "Editar avatar",
+    "usernameLabel": "Nome de usuário",
+    "emailLabel": "E-mail",
+    "cancelButton": "Cancelar",
+    "saveButton": "Salvar"
+  },
+  "profileLogOut": {
+    "title": "Perfil",
+    "text": "Você deve estar logado para acessar este conteúdo.",
+    "button": "Login"
+  },
+  "ptiGuide": {
+    "title": "O que são tokens?",
+    "description": "Leitura recomendada antes de submeter vídeos",
+    "callToAction": "Descubra como usar seus créditos",
+    "ptiGuide": "Credits Guide",
+    "steps": {
+      "token": {
+        "mainContent": "PTI is the native token of the Paratii open system. We call it a \"system\" because the network executes operations with PTI although nobody \"owns\" the machinery who does the job.",
+        "subContent": "PTI tokens are issued, distributed and collected by smart contracts that live on the Ethereum blockchain. Every new registered user on Paratii earns some tokens to experiment with. They show up on the top right of this page (click that icon!) or in our embedded player, when one is watching through other sites. Let's see what you can do with PTI?"
+      },
+      "staking": {
+        "mainContent": "The basic operation here is staking. Whenever you upload a video, 5 of your tokens will be automatically \"attached to it\", as it enters the system. Think of it as a security deposit.",
+        "subContent": "At any time, you will be able to retrieve your tokens back, which also delists the video from this web portal and related interfaces. On the other hand, those who leave tokens staked are continuously granted rewards, issued through inflation, and can also earn profits if the playlists their videos belong to are performing well (these two functions are not live yet). So uploading content and staking are forms of active participation in this economy."
+      },
+      "flagging": {
+        "mainContent": "Videos will be subject to \"flags\". Flagging a video means matching its stake, by putting up an equivalent amount for challenge.",
+        "subContent": "Any user can then go in favour or disfavour that video’s presence on the system. Videos collectively rejected lose their stakes - forfeited PTI go to voters in the challenge (people who flagged or disapproved) and to all people actively staking tokens in the system, at the moment. That means that keeping a well curated record of videos - one that keeps attracting creators and spitting out harmful content - can be a profitable activity to the system's participants."
+      },
+      "conclusion": {
+        "mainContent": "Soon, PTI will also be usable for facilitating micro payments. Creators will have monetisation options to directly receive value from their audiences and/or advertisers.",
+        "subContent_html": "Most important for now is that you understand PTI as an entry ticket to take part in an economy that belongs to you as much as you are willing to belong to it. Tokens displayed here are in a test environment still, and have no monetary value. If you're willing to claim some extra test PTI, ask questions, or make suggestions about the token's feature set itself, don't hesitate to %{getInTouchEmailLink}.",
+        "getInTouch": "get in touch"
+      }
+    }
+  },
+  "uploadListItem": {
+    "statusMessage": {
+      "needsTitle": "Escreva um título e uma descrição.",
+      "videoReady": "✅ Vídeo pronto!",
+      "uploadFailed": "O upload do seu vídeo falhou.",
+      "transcodeFailed": "Seu vídeo falhou em ser transcodado.",
+      "transcoding": "Transcodando seu vídeo...",
+      "uploading": "Fazendo upload do vídeo..."
+    },
+    "title": "Título",
+    "description": "Descrição",
+    "ownership": "A quem os direitos deste vídeo pertencem? Por favor, aponte um link que comprove.",
+    "videoId": "Video Id",
+    "contentType": {
+      "title": "Que tipo de conteúdo?",
+      "free": "Gratuito",
+      "paid": "Pago (não disponível)"
+    },
+    "publish": "Publicar",
+    "termsOfService": "Ao \"Publicar\", você concorda com os Termos de Uso da Paratii. Não são permitidas violações de direito ou privacidade.",
+    "save": "Salvar",
+    "noVideo": "Nenhum vídeo selecionado!",
+    "insufficientBalance": {
+      "title": "Sem créditos suficientes",
+      "description": "Você precisa de %{amount} créditos para realizar esta ação."
+    }
+  },
+  "search": {
+    "input": {
+      "placeholder": "Buscar"
+    },
+    "results": {
+      "resultsFor": "O que encontramos sobre \"%{term}\":",
+      "noResultsFor": "Nenhum resultado para \"%{term}\"",
+      "moreResults": "Veja mais resultados",
+      "zeroState": "Escreva algumas palavras-chave acima para fazer uma busca.",
+      "relatedContent": "Conteúdo relacionado",
+      "relatedContentCategories": "Categorias:"
+    }
+  },
+  "tcr": {
+    "ChallengePeriod": {
+      "whitelistedTitle_html": "<strong>Período de votação</strong> acaba em",
+      "challengedTitle_html": "<strong>Período de desafio</strong> acaba em",
+      "inRevealTitle_html": "<strong>Período de relevação</strong> acaba em",
+      "whitelistedLabel": "Aprovados",
+      "challengedLabel": "Em votação",
+      "inRevealLabel": "Em revelação",
+      "hourLabel": "hora",
+      "minutesLabel": "minutos",
+      "secondsLabel": "segundos"
+    },
+    "CommitYourVote": {
+      "title": "Escolha um lado",
+      "text": "Vote YAY ou NAY sobre a permanência ou não deste vídeo na plataforma.",
+      "buttonSupport": "Yay",
+      "buttonOppose": "Nay"
+    },
+    "RevealYourVote": {
+      "title": "Você precisará revelar o seu voto mais tarde!",
+      "text": "Se você esquecer de fazê-lo, seu voto não contará, mas não perderá seus créditos.",
+      "button": "Revelar voto"
+    },
+    "VideoApproved": {
+      "title": "Este vídeo foi aprovado.",
+      "text": "A comunidade escolheu YAY. Este vídeo pode ser desafiado de novo em 6 dias."
+    },
+    "VideoRejected": {
+      "title": "Este vídeo foi rejeitado.",
+      "text": "A comunidade escolheu NAY. Este vídeo foi delistado, provavelmente por violar os termos de uso da plataforma."
+    },
+    "VoteCommitted": {
+      "title": "Voto comprometido",
+      "text_html": "Quando o período de comprometimento acabar, volte para revelar seu voto. Você deverá enviá-lo <strong>back</strong> durante o período de revelação. Se não revelá-lo, seu voto não contará."
+    },
+    "VoteRevealed": {
+      "title": "Voto revelado",
+      "text": "Seu voto foi revelado. Agora é só esperar o fim do período de revelação para sabermos o resultado."
+    },
+    "Voting": {
+      "title": "Votar",
+      "box1Label": "Yay",
+      "box2Label": "Nay",
+      "dateLabel": "Data do desafio:"
+    },
+    "WhiteListed": {
+      "title": "Este vídeo está ",
+      "text": "Este vídeo fo publicado na rede. Se estiver violando nossos termos de uso, desafie ele para competir por recompensas.",
+      "button": "Desafiar"
+    }
+  },
+  "tipping": {
+    "giveTip": "Fazer doação",
+    "amounts": {
+      "10": "10",
+      "15": "15",
+      "20": "20",
+      "25": "25"
+    },
+    "defaultAuthor": "o autor",
+    "tippingError": "Algo deu errado com o envio.",
+    "steps": {
+      "chooseAmount": {
+        "header": "Sentindo-se generoso?",
+        "chooseTip": "Escolha quanto quer doar a %{username} :"
+      },
+      "enterPassword": {
+        "header": "Confirmando doação",
+        "inputPlaceholder": "Senha",
+        "continue": "Continuar",
+        "wrongPassword": "Senha incorreta"
+      },
+      "completed": {
+        "header1": "%{username} agradece.",
+        "header2": "Valeu por fazer o dia de %{username} mais feliz.",
+        "header3": "Doações são como abraços. Sem todo o contato físico.",
+        "continueWatching": "Continuar assistindo"
+      }
+    }
+  },
+  "uploader": {
+    "dragFiles": "Arraste arquivos aqui",
+    "filesInstructions_html": "%{dragFiles} ou clique para buscá-los na sua máquina",
+    "supportedFileTypes": "(apenas .mp4 <2gb atualmente suportado)",
+    "youtubeOrVimeo": "(Não-funcional) Ou faça upload a partir do YouTube / Vimeo",
+    "notifications": {
+      "starting": {
+        "title": "Aguarde...",
+        "description": "Preparando seu arquivo para a jornada."
+      },
+      "uploadError": {
+        "title": "Erro de upload:",
+        "description": "Algo deu errado com o upload do arquivo. Tente novamente."
+      },
+      "uploaded": {
+        "title": "Upload completo:",
+        "description": "Seus pixels agora estão sendo transcodados."
+      },
+      "transcodeError": {
+        "title": "Erro de transcoding:",
+        "description": "As máquinas não estão cooperando. Pode recarregar a página?"
+      },
+      "transcoding": {
+        "title": "Transcodando:",
+        "description": "Aquele processo com nome estranho: soa como se estivessem mastigando seu vídeo."
+      },
+      "transcoded": {
+        "title": "Transcoding finalizado:",
+        "description": "✅ Vídeo pronto para ser publicado!"
+      },
+      "saving": {
+        "title": "Salvando dados..."
+      },
+      "saved": {
+        "title": "Salvo",
+        "description": "Dados salvos!"
+      },
+      "saveError": {
+        "title": "❌ Erro em salvar dados."
+      },
+      "fileError": {
+        "title": "❌ Arquivo inválido:",
+        "description": "Formato de arquivo não suportado. Use arquivos .mp4 com menos de 2GB."
+      }
+    }
+  },
+  "userNav": {
+    "dataLabel": "Desde",
+    "leftBoxTitle": "Disponível",
+    "rightBoxTitle": "Investido"
+  },
+  "videoNotFound": {
+    "title": "Houston, temos um problema.",
+    "description": "Pouso não completado. Vídeo não existente, ou link errado. Se quiser ajudar, nos conta como chegou aqui:",
+    "linkText": "Paratii-Video"
+  },
+  "wallet": {
+    "securingWallet": "Criando uma conta...",
+    "walletSecured": "Você tem uma conta!",
+    "unlockingKeystore": "Acessando a carteira da sua conta...",
+    "enterPassword": {
+      "title": "Insira sua senha",
+      "description": "Favor inserir a sua senha para utilizar todos os recursos do Lab.",
+      "inputPlaceholder": "Insira sua senha",
+      "forgotPassword": "Esqueci minha senha",
+      "continue": "Continuar",
+      "success": {
+        "title": "✅ Sucesso!",
+        "description": "Sua conta está pronta para uso."
+      },
+      "error": {
+        "title": "A senha não está correta.",
+        "description": "Por favor escreve sua senha novamente.",
+        "formErrorMessage": "A senha não é válida, favor reescrevê-la."
+      }
+    },
+    "restoreAccount": {
+      "title": "Lembra daquelas 12 palavras que te pedimos pra guardar?",
+      "description": "Reescreva as 12 palavras (chave da conta) para continuar o processo.",
+      "mnemonic": "Chave da conta (12 palavras)",
+      "continue": "Continuar",
+      "goBack": "Voltar",
+      "errorMessage": "As 12 palavras inseridas não são válidas."
+    },
+    "secureAccount": {
+      "title": "Pronto para fazer uma conta?",
+      "description": "São só 3 passos.",
+      "alreadyHaveAccount": "Já tenho uma conta",
+      "secureThisAccount": "Criar nova conta"
+    },
+    "choosePassword": {
+      "title": "Crie uma senha.",
+      "description_html": "Use 89 caracteres ou mais. Inclua ao menos 1 letra maiúscula e 1 número.",
+      "newPasswordLabel": "Senha",
+      "confirmPasswordLabel": "Confirmar senha",
+      "continue": "Continuar",
+      "back": "Voltar",
+      "errors": {
+        "passwordMismatch": "Máquina. Está. Confusa. As senhas não batem!",
+        "eightCharacters": "Por favor, use 8 caracteres ou mais.",
+        "numericCharacter": "A senha deve ter ao menos 1 número.",
+        "uppercaseCharacter": "A senha deve ter ao menos 1 letra maiúscula."
+      }
+    },
+    "showSeed": {
+      "title": "🔑 Voilá: aqui está a chave da sua conta.",
+      "description_html": "Está é a única prova de que você é o dono dessa conta. %{keepSafe}",
+      "keepSafe": "Guarde-a em um lugar seguro. Mantenha a chave secreta.",
+      "copy": {
+        "buttonText": "Copiar",
+        "confirmCopy": "Já copiei as 12 palavras. Elas estão seguras e protegidas.",
+        "notification": {
+          "title": "Copiado!",
+          "description": "A chave da sua conta foi copiada para o clipboard."
+        }
+      },
+      "goBack": "Voltar",
+      "continue": "Continuar"
+    }
+  }
 }


### PR DESCRIPTION
Closes #718

Changes:
1. **Client-side file validation** in FileUploader.js — checks file type (.mp4) and size (<2GB) before upload starts, with clear error messages
2. **MAX_FILE_SIZE constant** (2GB) in UploaderConstants.js
3. **Updated upload notice** — shows "(only .mp4 <2gb currently supported)"
4. **Translation updates** for en.json and pt-BR.json

Before this PR:
- Uploading an unsupported format simply showed "Something went wrong with your file"
- No size guidance was shown on the upload screen

After this PR:
- Users see file format/size requirements before uploading
- Invalid files are rejected immediately with a clear message
- The upload notice now includes the 2GB limit